### PR TITLE
FORMS-387: Use the SiteMessage form with a backurl

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -785,7 +785,7 @@ public class FormXPage extends MVCApplication
         if ( currentStep == null )
         {
         	 FormMessage formMessage = FormMessageHome.findByForm( form.getId( ) );
-	         SiteMessageService.setMessage( request, MESSAGE_ERROR_CONTROL, new Object[] { errorList.stream( ).collect( Collectors.joining( ) ) }, SiteMessage.TYPE_ERROR, getBackUrl( form, formMessage.getEndMessageDisplay( ) ), null );
+	         SiteMessageService.setMessage( request, MESSAGE_ERROR_CONTROL, new Object[] { errorList.stream( ).collect( Collectors.joining( ) ) }, null, null, null, SiteMessage.TYPE_ERROR, null, getBackUrl( form, formMessage.getEndMessageDisplay( ) ) );
 		}
         return redirectView( request, VIEW_STEP );
     }


### PR DESCRIPTION
This allows the message to display only a back button instead of two
buttons that go to the same page.