### PR TITLE
FORMS-400: group iterations together

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/export/csv/CSVHeader.java
+++ b/src/java/fr/paris/lutece/plugins/forms/export/csv/CSVHeader.java
@@ -35,9 +35,9 @@ package fr.paris.lutece.plugins.forms.export.csv;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ListIterator;
 
 import fr.paris.lutece.plugins.forms.business.Question;
-import fr.paris.lutece.portal.service.i18n.I18nService;
 
 /**
  * This class represents a CSV header
@@ -45,25 +45,14 @@ import fr.paris.lutece.portal.service.i18n.I18nService;
  */
 public class CSVHeader
 {
-    private static final String MESSAGE_EXPORT_FORM_TITLE = "forms.export.formResponse.form.title";
-    private static final String MESSAGE_EXPORT_FORM_DATE_CREATION = "forms.export.formResponse.form.date.creation";
-
-    private final List<String> _listFormResponseColumn;
-    private final List<String> _listQuestionColumn;
-
-    private final List<String> _listColumnToExport;
+    private final List<Question> _listQuestionColumn;
 
     /**
      * Constructor
      */
     public CSVHeader( )
     {
-        _listFormResponseColumn = new ArrayList<>( );
         _listQuestionColumn = new ArrayList<>( );
-        _listColumnToExport = new ArrayList<>( );
-
-        _listFormResponseColumn.add( I18nService.getLocalizedString( MESSAGE_EXPORT_FORM_TITLE, I18nService.getDefaultLocale( ) ) );
-        _listFormResponseColumn.add( I18nService.getLocalizedString( MESSAGE_EXPORT_FORM_DATE_CREATION, I18nService.getDefaultLocale( ) ) );
     }
 
     /**
@@ -72,31 +61,41 @@ public class CSVHeader
      * @param question
      *            the question to add
      */
-    public void addHeader( Question question )
-    {
-        String strColumnName = CSVUtil.buildColumnName( question );
-
-        if ( !_listQuestionColumn.contains( strColumnName ) )
-        {
-            _listQuestionColumn.add( strColumnName );
-        }
-    }
-
-    /**
-     * Build the final list of column to export (with iteration number)
-     */
-    public void buildColumnToExport( )
-    {
-        _listColumnToExport.clear( );
-        _listColumnToExport.addAll( _listFormResponseColumn );
-        _listColumnToExport.addAll( _listQuestionColumn );
-    }
+	public void addHeader( Question question )
+	{
+		ListIterator<Question> listIterator = _listQuestionColumn.listIterator( );
+		boolean foundQuestionWithSameId = false;
+		while ( listIterator.hasNext( ) )
+		{
+			Question aQuestion = listIterator.next( );
+			if ( aQuestion.getId( ) == question.getId( ) )
+			{
+				if ( aQuestion.getIterationNumber( ) == question.getIterationNumber( ) )
+				{
+					return;
+				}
+				if ( aQuestion.getIterationNumber( ) > question.getIterationNumber( ) )
+				{
+					listIterator.previous( );
+					listIterator.add( question );
+					return;
+				}
+				foundQuestionWithSameId = true;
+			} else if ( foundQuestionWithSameId )
+			{
+				listIterator.previous( );
+				listIterator.add( question );
+				return;
+			}
+		}
+		_listQuestionColumn.add( question );
+	}
 
     /**
      * @return the _listFinalColumnToExport
      */
-    public List<String> getColumnToExport( )
+    public List<Question> getColumnToExport( )
     {
-        return _listColumnToExport;
+        return _listQuestionColumn;
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/export/csv/CSVUtil.java
+++ b/src/java/fr/paris/lutece/plugins/forms/export/csv/CSVUtil.java
@@ -34,6 +34,7 @@
 package fr.paris.lutece.plugins.forms.export.csv;
 
 import fr.paris.lutece.plugins.forms.business.Question;
+import fr.paris.lutece.plugins.forms.util.FormsConstants;
 
 /**
  * This class provides utilitary methods for CSV export
@@ -43,6 +44,7 @@ public final class CSVUtil
 {
     private static final String ITERATION_PREFIX = " (";
     private static final String ITERATION_SUFFIX = ")";
+    private static final char DOUBLE_QUOTE = '\"';
 
     /**
      * Constructor
@@ -70,5 +72,24 @@ public final class CSVUtil
         }
 
         return strColumnName;
+    }
+
+    /**
+     * Make the specified value safe for the CSV export
+     *
+     * @param strValue
+     *            the value
+     * @return the safe value
+     */
+    static String safeString( String strValue )
+    {
+        String strSafeString = strValue;
+
+        if ( strSafeString.contains( FormsConstants.SEPARATOR_SEMICOLON ) )
+        {
+            strSafeString = new StringBuilder( DOUBLE_QUOTE ).append( strSafeString ).append( DOUBLE_QUOTE ).toString( );
+        }
+
+        return strSafeString;
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/export/csv/FormResponseCsvExport.java
+++ b/src/java/fr/paris/lutece/plugins/forms/export/csv/FormResponseCsvExport.java
@@ -42,7 +42,9 @@ import org.apache.commons.lang3.StringUtils;
 import fr.paris.lutece.plugins.forms.business.FormQuestionResponse;
 import fr.paris.lutece.plugins.forms.business.FormResponse;
 import fr.paris.lutece.plugins.forms.business.FormResponseStep;
+import fr.paris.lutece.plugins.forms.business.Question;
 import fr.paris.lutece.plugins.forms.util.FormsConstants;
+import fr.paris.lutece.portal.service.i18n.I18nService;
 
 /**
  * 
@@ -53,7 +55,8 @@ public class FormResponseCsvExport
 {
     private static final String SEPARATOR = FormsConstants.SEPARATOR_SEMICOLON;
     private static final String END_OF_LINE = FormsConstants.END_OF_LINE;
-    private static final String DOUBLE_QUOTE = "\"";
+    private static final String MESSAGE_EXPORT_FORM_TITLE = "forms.export.formResponse.form.title";
+    private static final String MESSAGE_EXPORT_FORM_DATE_CREATION = "forms.export.formResponse.form.date.creation";
 
     private final CSVHeader _csvHeader = new CSVHeader( );
 
@@ -94,37 +97,24 @@ public class FormResponseCsvExport
     /**
      * Build the CSV string for column line
      */
-    private void buildCsvColumnToExport( )
-    {
-        StringBuilder sbCsvColumn = new StringBuilder( );
-        _csvHeader.buildColumnToExport( );
+	private void buildCsvColumnToExport( )
+	{
+		StringBuilder sbCsvColumn = new StringBuilder( );
 
-        for ( String strColumnName : _csvHeader.getColumnToExport( ) )
-        {
-            sbCsvColumn.append( safeString( strColumnName ) ).append( SEPARATOR );
-        }
+		sbCsvColumn.append( CSVUtil.safeString(
+				I18nService.getLocalizedString( MESSAGE_EXPORT_FORM_TITLE, I18nService.getDefaultLocale( ) ) ) );
+		sbCsvColumn.append( SEPARATOR );
+		sbCsvColumn.append( CSVUtil.safeString( I18nService.getLocalizedString( MESSAGE_EXPORT_FORM_DATE_CREATION,
+				I18nService.getDefaultLocale( ) ) ) );
+		sbCsvColumn.append( SEPARATOR );
 
-        _strCsvColumnToExport = sbCsvColumn.append( END_OF_LINE ).toString( );
-    }
+		for ( Question question : _csvHeader.getColumnToExport( ) )
+		{
+			sbCsvColumn.append( CSVUtil.safeString( CSVUtil.buildColumnName( question ) ) ).append( SEPARATOR );
+		}
 
-    /**
-     * Make the specified value safe for the CSV export
-     * 
-     * @param strValue
-     *            the value
-     * @return the safe value
-     */
-    private String safeString( String strValue )
-    {
-        String strSafeString = strValue;
-
-        if ( strSafeString.contains( SEPARATOR ) )
-        {
-            strSafeString = new StringBuilder( DOUBLE_QUOTE ).append( strSafeString ).append( DOUBLE_QUOTE ).toString( );
-        }
-
-        return strSafeString;
-    }
+		_strCsvColumnToExport = sbCsvColumn.append( END_OF_LINE ).toString( );
+	}
 
     /**
      * Build the CSV string for all data lines
@@ -136,10 +126,11 @@ public class FormResponseCsvExport
         for ( CSVDataLine csvDataLine : _listDataToExport )
         {
             StringBuilder sbRecordContent = new StringBuilder( );
+            sbRecordContent.append( csvDataLine.getCommonDataToExport( ) );
 
-            for ( String strColumnName : _csvHeader.getColumnToExport( ) )
+            for ( Question question : _csvHeader.getColumnToExport( ) )
             {
-                sbRecordContent.append( safeString( Objects.toString( csvDataLine.getDataToExport( strColumnName ), StringUtils.EMPTY ) ) ).append( SEPARATOR );
+                sbRecordContent.append( CSVUtil.safeString( Objects.toString( csvDataLine.getDataToExport( question ), StringUtils.EMPTY ) ) ).append( SEPARATOR );
             }
 
             sbCsvData.append( sbRecordContent.toString( ) ).append( END_OF_LINE );

--- a/src/test/java/fr/paris/lutece/plugins/forms/export/csv/CSVHeaderTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/forms/export/csv/CSVHeaderTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2002-2019, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.forms.export.csv;
+
+import java.util.List;
+
+import fr.paris.lutece.plugins.forms.business.Question;
+import junit.framework.TestCase;
+
+public class CSVHeaderTest extends TestCase
+{
+
+	public void testAddHeader( )
+	{
+		Question q1 = getQuestion( 3, 0 );
+		Question q2 = getQuestion( 2, 0 );
+		Question q3 = getQuestion( 1, 0 );
+
+		CSVHeader header = new CSVHeader( );
+
+		header.addHeader( q1 );
+		header.addHeader( q2 );
+		header.addHeader( q3 );
+
+		List<Question> questions = header.getColumnToExport( );
+
+		assertNotNull( questions );
+		assertEquals( 3, questions.size( ) );
+		assertEquals( q1, questions.get( 0 ) );
+		assertEquals( q2, questions.get( 1 ) );
+		assertEquals( q3, questions.get( 2 ) );
+	}
+
+	public void testAddHeaderSameQuestion( )
+	{
+		Question q1 = getQuestion( 1, 0 );
+		Question q1_bis = getQuestion( 1, 0 );
+
+		CSVHeader header = new CSVHeader( );
+
+		header.addHeader( q1 );
+		header.addHeader( q1_bis );
+
+		List<Question> questions = header.getColumnToExport( );
+
+		assertNotNull( questions );
+		assertEquals( 1, questions.size( ) );
+		assertEquals( q1, questions.get( 0 ) );
+	}
+
+	public void testAddHeaderIteration( )
+	{
+		Question q1 = getQuestion( 1, 0 );
+		Question q2 = getQuestion( 2, 0 );
+		Question q1_bis = getQuestion( 1, 1 );
+
+		CSVHeader header = new CSVHeader( );
+
+		header.addHeader( q1 );
+		header.addHeader( q2 );
+		header.addHeader( q1_bis );
+
+		List<Question> questions = header.getColumnToExport( );
+
+		assertNotNull( questions );
+		assertEquals( 3, questions.size( ) );
+		assertEquals( q1, questions.get( 0 ) );
+		assertEquals( q1_bis, questions.get( 1 ) );
+		assertEquals( q2, questions.get( 2 ) );
+	}
+
+	public void testAddHeaderIterationWithHole( )
+	{
+		Question q1 = getQuestion( 1, 0 );
+		Question q2 = getQuestion( 2, 0 );
+		Question q1_bis = getQuestion( 1, 2 );
+		Question q1_ter = getQuestion( 1, 1 );
+
+		CSVHeader header = new CSVHeader( );
+
+		header.addHeader( q1 );
+		header.addHeader( q2 );
+		header.addHeader( q1_bis );
+		header.addHeader( q1_ter );
+
+		List<Question> questions = header.getColumnToExport( );
+
+		assertNotNull( questions );
+		assertEquals( 4, questions.size( ) );
+		assertEquals( q1, questions.get( 0 ) );
+		assertEquals( q1_ter, questions.get( 1 ) );
+		assertEquals( q1_bis, questions.get( 2 ) );
+		assertEquals( q2, questions.get( 3 ) );
+	}
+
+	private Question getQuestion( int nId, int nIterationNumber )
+	{
+		Question question = new Question( );
+		question.setId( nId );
+		question.setIterationNumber( nIterationNumber );
+		return question;
+	}
+
+}


### PR DESCRIPTION
When all response do not have the same number of iterations for a
question, corresponding columns could be separated.
We thus build the column list by taking into account the question ID and
iteration number, and grouping questions with the same ID, in the
iteration number order.

One change in behavior is that questions with the same title are now
exported on different columns.