### PR TITLE
FORMS-426: Correct typo in popup options

### DIFF
--- a/webapp/js/plugins/forms/terms-of-service.js
+++ b/webapp/js/plugins/forms/terms-of-service.js
@@ -1,5 +1,5 @@
 function openFormsTermsOfService(url)
 {
-  var forms_win_terms_of_service = self.open(url, 'forms_terms_of_service', 'toolbar=no,location=no,directories=no,status=yes,menubar=no,scrollbar=yes,resizable=yes,copyhistory=yes,width=500px,height=300px');
+  var forms_win_terms_of_service = self.open(url, 'forms_terms_of_service', 'toolbar=no,location=no,directories=no,status=yes,menubar=no,scrollbars=yes,resizable=yes,copyhistory=yes,width=500px,height=300px');
   forms_win_terms_of_service.focus();
 }


### PR DESCRIPTION
The scrollbar would not appear with older browsers (IE11, FireFox 45)