### PR TITLE
FORMS-644: Remove stray nbsp html entity in question move dialog

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/resources/forms_messages.properties
+++ b/src/java/fr/paris/lutece/plugins/forms/resources/forms_messages.properties
@@ -690,7 +690,7 @@ message.mandatory.termsOfService=Please accept the terms of service.
 message.field_value_field=The field value should not contain special characters or spaces
 message.confirmRemoveMapping=Are you sure to want to delete this mapping ?
 
-move_composite.title=Moving element:&nbsp;
+move_composite.title=Moving element: {0}
 moveComposite.step.label=Step
 moveComposite.group.label=Parent group
 moveComposite.step.label.help=Select a target step

--- a/src/java/fr/paris/lutece/plugins/forms/resources/forms_messages_fr.properties
+++ b/src/java/fr/paris/lutece/plugins/forms/resources/forms_messages_fr.properties
@@ -691,7 +691,7 @@ message.mandatory.termsOfService=Veuillez accepter les conditions g\u00e9n\u00e9
 message.field_value_field=Le champ valeur ne doit pas contenir de caract&#232;res sp\u00e9ciaux ou d'espaces
 message.confirmRemoveMapping=Etes-vous s&#251;r de vouloir supprimer ce mapping ?
 
-move_composite.title=D\u00e9placement de l'\u00e9l\u00e9ment:&nbsp;
+move_composite.title=Déplacement de l''élément\u202F: {0}
 moveComposite.step.label=Etape
 moveComposite.group.label=Groupe parent
 moveComposite.step.label.help=S\u00e9lectionner une \u00e9tape de destination

--- a/webapp/WEB-INF/templates/admin/plugins/forms/move_composite.html
+++ b/webapp/WEB-INF/templates/admin/plugins/forms/move_composite.html
@@ -1,7 +1,7 @@
 <@formBreadCrumb>
     <li><@link href='jsp/admin/plugins/forms/ManageSteps.jsp?view=manageSteps&id_form=${step.idForm}' title='#i18n{forms.create_form.button.backForm}'>...</@link></li>
     <li><@link href='jsp/admin/plugins/forms/ManageQuestions.jsp?view=manageQuestions&id_step=${step.id}' title='#i18n{forms.create_form.button.backStep}'>${step.title}</@link></li>
-    <li class="active">#i18n{forms.move_composite.title} ${display_title!}</li>
+    <li class="active">${i18n('forms.move_composite.title',display_title!)?html}</li>
 </@formBreadCrumb>
 
 <@tform method='post' id='modify_form' name='modify_form' action='jsp/admin/plugins/forms/ManageQuestions.jsp'>
@@ -71,7 +71,7 @@ $( function() {
 			});
 		});
 
-		var modalTitle = "#i18n{forms.move_composite.title} ${display_title!}";
+		var modalTitle = "${i18n('forms.move_composite.title',display_title!)?js_string}";
 		window.parent.$("#qModal").find(".modal-title").text(modalTitle);
     } else {
         $('#pubModal .content-header').hide();


### PR DESCRIPTION
In french, there is a thin non breaking space before a colon, and a normal space after.
In english, there is no space before a colon, and a normal space after.

Integrate the variable into the i18n message, and properly escape it in the template.