### PR TITLE
FORMS-713: Add a protected way to test a form when not published

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/resources/forms_messages.properties
+++ b/src/java/fr/paris/lutece/plugins/forms/resources/forms_messages.properties
@@ -851,6 +851,7 @@ message.mandatory.entry=This field is mandatory.
 message.errorUniqueField=This field already exists, please type another one.
 message.geolocation.checkAdress=You have to choose an address in the list.
 message.numberResponse.label=Number of submissions for this form : 
+warning.inactive.state.bypassed=This form is inactive. Responses will not be saved.
 
 step.previous=Previous step
 step.next=Next step

--- a/src/java/fr/paris/lutece/plugins/forms/resources/forms_messages_fr.properties
+++ b/src/java/fr/paris/lutece/plugins/forms/resources/forms_messages_fr.properties
@@ -851,6 +851,7 @@ message.mandatory.entry=Ce champ est obligatoire.
 message.errorUniqueField=Ce champ existe d\u00e9j&#224;, veuillez en saisir un autre.
 message.geolocation.checkAdress=Vous devez s\u00e9lectionner un adresse dans la liste propos\u00e9
 message.numberResponse.label=Nombre de r\u00e9ponses d\u00e9j\u00e0 post\u00e9es pour ce formulaire : 
+warning.inactive.state.bypassed=Ce formulaire est inactif. Les réponses ne seront pas enregistrées.
 
 step.previous=Etape pr\u00e9c\u00e9dente
 step.next=Etape suivante

--- a/src/java/fr/paris/lutece/plugins/forms/util/FormsConstants.java
+++ b/src/java/fr/paris/lutece/plugins/forms/util/FormsConstants.java
@@ -90,6 +90,9 @@ public final class FormsConstants
     public static final String MARK_ANONYMIZATION_HELP = "anonymization_help_message";
     public static final String MARK_BREADCRUMBS = "breadcrumb_template";
     public static final String VALUE_VALIDATOR_LISTEQUESTION_NAME = "forms_listQuestionValidator";
+    public static final String MARK_TIMESTAMP = "timestamp";
+    public static final String MARK_INACTIVEBYPASSTOKENS = "inactiveBypassTokens";
+
 
     // Parameters
     public static final String PARAMETER_PAGE = "page";
@@ -137,6 +140,8 @@ public final class FormsConstants
     public static final String PARAMETER_DISPLAYED_QUESTIONS = "displayed_questions";
     public static final String PARAMETER_INIT = "init";
     public static final String PARAMETER_ID_QUESTION_TO_REMOVE = "id_rm_question";
+    public static final String PARAMETER_TIMESTAMP = "ts";
+    public static final String PARAMETER_TOKEN = "token";
 
     public static final String PARAMETER_SELECTED_PANEL = "selected_panel";
     public static final String PARAMETER_CURRENT_SELECTED_PANEL = "current_selected_panel";
@@ -166,6 +171,7 @@ public final class FormsConstants
     public static final String PROPERTY_MY_LUTECE_ATTRIBUTES_LIST = "entrytype.myluteceuserattribute.attributes.list";
     public static final String CONSTANT_MYLUTECE_ATTRIBUTE_I18N_PREFIX = "forms.entrytype.myluteceuserattribute.attribute.";
     public static final String PROPERTY_EXPORT_FORM_DATE_CREATION_FORMAT = "forms.export.formResponse.form.date.creation.format";
+    public static final String PROPERTY_INACTIVE_BYPASS_DURATION_MILLISECONDS = "forms.inactive.bypass.duration.milliseconds";
 
     // Constants
     public static final int DEFAULT_FILTER_VALUE = NumberUtils.INTEGER_MINUS_ONE;

--- a/src/java/fr/paris/lutece/plugins/forms/util/FormsUtils.java
+++ b/src/java/fr/paris/lutece/plugins/forms/util/FormsUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2021, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.forms.util;
+
+import fr.paris.lutece.plugins.forms.business.Form;
+import fr.paris.lutece.portal.service.util.CryptoService;
+
+/**
+ * Utilities for forms
+ */
+public class FormsUtils
+{
+    private FormsUtils( )
+    {
+        // utility class
+    }
+
+    /**
+     * Get a token to bypass the inactive state of the form
+     * 
+     * @param form
+     *            the form
+     * @param strTimestamp
+     *            the timestamp for the start of the bypass period
+     * @return a token
+     */
+    public static String getInactiveBypassToken( Form form, String strTimestamp )
+    {
+        StringBuilder builder = new StringBuilder( );
+        builder.append( "formId:" ).append( form.getId( ) ).append( ":timestamp:" ).append( strTimestamp );
+        return CryptoService.hmacSHA256( builder.toString( ) );
+    }
+
+}

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormsDashboardComponent.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormsDashboardComponent.java
@@ -34,9 +34,11 @@
 package fr.paris.lutece.plugins.forms.web;
 
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -47,6 +49,8 @@ import fr.paris.lutece.plugins.forms.business.Form;
 import fr.paris.lutece.plugins.forms.business.FormAction;
 import fr.paris.lutece.plugins.forms.business.FormActionHome;
 import fr.paris.lutece.plugins.forms.business.FormHome;
+import fr.paris.lutece.plugins.forms.util.FormsConstants;
+import fr.paris.lutece.plugins.forms.util.FormsUtils;
 import fr.paris.lutece.portal.business.right.Right;
 import fr.paris.lutece.portal.business.right.RightHome;
 import fr.paris.lutece.portal.business.user.AdminUser;
@@ -105,10 +109,15 @@ public class FormsDashboardComponent extends DashboardComponent
             List<FormAction> listAuthorisedActions = (List<FormAction>) RBACService.getAuthorizedActionsCollection( listFormActions, form, (User) user );
             form.setActions( listAuthorisedActions );
         }
+        String strTimespamp = Long.toString( new Date( ).getTime( ) );
+        Map<String, String> formIdToToken = displayList.stream( ).filter( f -> !f.isActive( ) )
+                .collect( Collectors.toMap( f -> Integer.toString(  f.getId( ) ), f -> FormsUtils.getInactiveBypassToken( f, strTimespamp ) ) );
 
         Map<String, Object> model = new HashMap<>( );
         model.put( MARK_FORM_LIST, displayList );
         model.put( MARK_URL, url.getUrl( ) );
+        model.put( FormsConstants.MARK_TIMESTAMP, strTimespamp );
+        model.put( FormsConstants.MARK_INACTIVEBYPASSTOKENS, formIdToToken );
 
         HtmlTemplate t = AppTemplateService.getTemplate( TEMPLATE_DASHBOARD, user.getLocale( ), model );
 

--- a/src/java/fr/paris/lutece/plugins/forms/web/admin/FormJspBean.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/admin/FormJspBean.java
@@ -33,10 +33,12 @@
  */
 package fr.paris.lutece.plugins.forms.web.admin;
 
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -61,6 +63,7 @@ import fr.paris.lutece.plugins.forms.service.FormService;
 import fr.paris.lutece.plugins.forms.service.FormsResourceIdService;
 import fr.paris.lutece.plugins.forms.service.json.FormJsonService;
 import fr.paris.lutece.plugins.forms.util.FormsConstants;
+import fr.paris.lutece.plugins.forms.util.FormsUtils;
 import fr.paris.lutece.plugins.forms.web.breadcrumb.BreadcrumbManager;
 import fr.paris.lutece.plugins.genericattributes.business.GenAttFileItem;
 import fr.paris.lutece.portal.business.file.File;
@@ -240,6 +243,10 @@ public class FormJspBean extends AbstractJspBean
 
         }
 
+        String strTimespamp = Long.toString( new Date( ).getTime( ) );
+        Map<String, String> formIdToToken = paginator.getPageItems( ).stream( ).filter( f -> !f.isActive( ) )
+                .collect( Collectors.toMap( f -> Integer.toString(  f.getId( ) ), f -> FormsUtils.getInactiveBypassToken( f, strTimespamp ) ) );
+
         model.put( MARK_PAGINATOR, paginator );
         model.put( MARK_NB_ITEMS_PER_PAGE, EMPTY_STRING + _nItemsPerPage );
 
@@ -248,6 +255,8 @@ public class FormJspBean extends AbstractJspBean
         model.put( MARK_PERMISSION_CREATE_FORMS,
                 RBACService.isAuthorized( Form.RESOURCE_TYPE, RBAC.WILDCARD_RESOURCES_ID, FormsResourceIdService.PERMISSION_CREATE, (User) adminUser ) );
         model.put( MARK_IS_ACTIVE_KIBANA_FORMS_PLUGIN, PluginService.isPluginEnable( KIBANA_FORMS_PLUGIN_NAME ) );
+        model.put( FormsConstants.MARK_TIMESTAMP, strTimespamp );
+        model.put( FormsConstants.MARK_INACTIVEBYPASSTOKENS, formIdToToken );
 
         setPageTitleProperty( EMPTY_STRING );
 

--- a/webapp/WEB-INF/conf/plugins/forms.properties
+++ b/webapp/WEB-INF/conf/plugins/forms.properties
@@ -28,3 +28,6 @@ forms.export.pdf.zip=false
 
 # Duration in minutes of the validity of generated url for file download (if 0, the links will be always valid)
 forms.file.download.validity=0
+
+# Duration in milliseconds of the validity of the link to test a form that is not active
+#forms.inactive.bypass.duration.milliseconds=1800000

--- a/webapp/WEB-INF/templates/admin/plugins/forms/dashboard/form_dashboard.html
+++ b/webapp/WEB-INF/templates/admin/plugins/forms/dashboard/form_dashboard.html
@@ -34,8 +34,13 @@
 					</#list>
 				</#if>
 				<#if form.active>
-					<@aButton href='jsp/site/Portal.jsp?page=forms&view=stepView&id_form=${form.id}&init=true' title='#i18n{forms.manageForm.FOLink.label} ${form.title}' hideTitle=['all'] params='target="_blank"' buttonIcon='external-link' size='sm' color='success' />
+					<#assign inactiveBypass=''>
+					<#assign color='success'>
+				<#else>
+					<#assign inactiveBypass='&ts='+timestamp+'&token='+inactiveBypassTokens[form.id?string]>
+					<#assign color='warning'>
 				</#if>
+				<@aButton href='jsp/site/Portal.jsp?page=forms&view=stepView&id_form=${form.id}&init=true${inactiveBypass}' title='#i18n{forms.manageForm.FOLink.label} ${form.title}' hideTitle=['all'] params='target="_blank"' buttonIcon='external-link' size='sm' color=color />
 			</@td>
 			
 		</@tr>

--- a/webapp/WEB-INF/templates/admin/plugins/forms/manage_forms.html
+++ b/webapp/WEB-INF/templates/admin/plugins/forms/manage_forms.html
@@ -71,8 +71,13 @@
                                     </#list>
                                 </#if>
                                 <#if form.active>
-                                    <@aButton href='jsp/site/Portal.jsp?page=forms&view=stepView&id_form=${form.id}&init=true' title='#i18n{forms.manageForm.FOLink.label} ${form.title}' hideTitle=['all'] params='target="_blank"' buttonIcon='external-link' size='sm' color='success' />
+                                	<#assign inactiveBypass=''>
+                                	<#assign color='success'>
+                                <#else>
+                                	<#assign inactiveBypass='&ts='+timestamp+'&token='+inactiveBypassTokens[form.id?string]>
+                                	<#assign color='warning'>
                                 </#if>
+                                <@aButton href='jsp/site/Portal.jsp?page=forms&view=stepView&id_form=${form.id}&init=true${inactiveBypass}' title='#i18n{forms.manageForm.FOLink.label} ${form.title}' hideTitle=['all'] params='target="_blank"' buttonIcon='external-link' size='sm' color=color />
                                 <#if is_active_kibana_forms_plugin>
                                 	<@aButton href='jsp/admin/plugins/kibana/KibanaDashboard.jsp?view=dashboard&tab=FormsDataSource_${form.id}' title='#i18n{forms.manageForm.stats.label}' hideTitle=['all'] params='target="_blank"' buttonIcon='chart-area' size='sm' color='info' />
                                 </#if>

--- a/webapp/WEB-INF/templates/skin/plugins/forms/form_submitted_view.html
+++ b/webapp/WEB-INF/templates/skin/plugins/forms/form_submitted_view.html
@@ -1,3 +1,4 @@
+	<@messages warnings=warnings />
 	<#if messageInfo?? >
 		${messageInfo}
 	</#if>


### PR DESCRIPTION
When a form is not published, a link to preview it is offered in the
backoffice which contains a cryptographic token and a timestamp.
By default, the link is valid for 30 minutes.

When accessed via this link, the form is usable but:
 * a warning is displayed a the top of pages
 * responses are not saved