### PR TITLE
LUT-25879: Introduce a cache service

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/business/Form.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/Form.java
@@ -130,6 +130,52 @@ public class Form implements AdminWorkgroupResource, RBACResource, Comparator<Fo
      **/
     private boolean _bAccessToResponsesByRole;
 
+    /**
+     * Default constructor
+     */
+    public Form( )
+    {
+        super( );
+    }
+
+    /**
+     * Copy constructor
+     * 
+     * Leaves out dynamic data
+     * 
+     * @param source
+     *            source Form to copy
+     */
+    Form( Form source )
+    {
+        _bAccessToResponsesByRole = source._bAccessToResponsesByRole;
+        _bAuthentificationNeeded = source._bAuthentificationNeeded;
+        _bBackupEnabled = source._bBackupEnabled;
+        _bCaptchaRecap = source._bCaptchaRecap;
+        _bCaptchaStepFinal = source._bCaptchaStepFinal;
+        _bCaptchaStepInitial = source._bCaptchaStepInitial;
+        _bCountResponses = source._bCountResponses;
+        _bDisplaySummary = source._bDisplaySummary;
+        _bOneResponseByUser = source._bOneResponseByUser;
+        _dateAvailabilityEndDate = source._dateAvailabilityEndDate;
+        _dateAvailabilityStartDate = source._dateAvailabilityStartDate;
+        _dateCreation = source._dateCreation;
+        _dateUpdate = source._dateUpdate;
+        _labelFinalButton = source._labelFinalButton;
+        // _listActions = null;
+        _logo = source._logo;
+        // _nCurrentNumberResponse = 0;
+        _nId = source._nId;
+        _nIdCategory = source._nIdCategory;
+        _nIdWorkflow = source._nIdWorkflow;
+        _nMaxNumberResponse = source._nMaxNumberResponse;
+        _strBreadcrumbName = source._strBreadcrumbName;
+        _strDescription = source._strDescription;
+        _strReturnUrl = source._strReturnUrl;
+        _strTitle = source._strTitle;
+        _strUnavailableMessage = source._strUnavailableMessage;
+        _strWorkgroup = source._strWorkgroup;
+    }
 
     /**
      * Returns the Id

--- a/src/java/fr/paris/lutece/plugins/forms/business/GroupHome.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/GroupHome.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.forms.business;
 
+import fr.paris.lutece.plugins.forms.service.cache.FormsCacheService;
 import fr.paris.lutece.portal.service.plugin.Plugin;
 import fr.paris.lutece.portal.service.plugin.PluginService;
 import fr.paris.lutece.portal.service.spring.SpringContextService;
@@ -47,6 +48,7 @@ public final class GroupHome
 {
     // Static variable pointed at the DAO instance
     private static IGroupDAO _dao = SpringContextService.getBean( "forms.groupDAO" );
+    private static FormsCacheService _cache = SpringContextService.getBean( "forms.cacheService" );
     private static Plugin _plugin = PluginService.getPlugin( "forms" );
 
     /**
@@ -66,7 +68,7 @@ public final class GroupHome
     public static Group create( Group group )
     {
         _dao.insert( group, _plugin );
-
+        _cache.putInCache( _cache.getGroupCacheKey( group.getId( ) ), group );
         return group;
     }
 
@@ -80,7 +82,7 @@ public final class GroupHome
     public static Group update( Group group )
     {
         _dao.store( group, _plugin );
-
+        _cache.putInCache( _cache.getGroupCacheKey( group.getId( ) ), group );
         return group;
     }
 
@@ -93,6 +95,7 @@ public final class GroupHome
     public static void remove( int nKey )
     {
         _dao.delete( nKey, _plugin );
+        _cache.removeKey( _cache.getGroupCacheKey( nKey ) );
     }
 
     /**
@@ -104,7 +107,14 @@ public final class GroupHome
      */
     public static Group findByPrimaryKey( int nKey )
     {
-        return _dao.load( nKey, _plugin );
+        String cacheKey = _cache.getGroupCacheKey( nKey );
+        Group group = ( Group ) _cache.getFromCache( cacheKey );
+        if ( group == null )
+        {
+            group = _dao.load( nKey, _plugin );
+            _cache.putInCache( cacheKey, group );
+        }
+        return group;
     }
 
     /**

--- a/src/java/fr/paris/lutece/plugins/forms/business/Question.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/Question.java
@@ -89,6 +89,43 @@ public class Question implements Serializable, Cloneable
     private int _nExportDisplayOrder;
 
     /**
+     * Default constructor
+     */
+    public Question( )
+    {
+        super( );
+    }
+
+    /**
+     * Copy constructor
+     * 
+     * Leaves out dynamic data
+     * 
+     * @param source
+     *            Question to copy
+     */
+    public Question( Question source )
+    {
+        _bIsFiltrableMultiviewFormSelected = source._bIsFiltrableMultiviewFormSelected;
+        _bIsFiltrableMultiviewGlobal = source._bIsFiltrableMultiviewGlobal;
+        _bIsVisible = source._bIsVisible;
+        _bIsVisibleMultiviewFormSelected = source._bIsVisibleMultiviewFormSelected;
+        _bIsVisibleMultiviewGlobal = source._bIsVisibleMultiviewGlobal;
+        _entry = source._entry;
+        _nExportDisplayOrder = source._nExportDisplayOrder;
+        _nId = source._nId;
+        _nIdEntry = source._nIdEntry;
+        _nIdStep = source._nIdStep;
+        // _nIterationNumber = 0;
+        _nMultiviewColumnOrder = source._nMultiviewColumnOrder;
+        _step = source._step;
+        _strCode = source._strCode;
+        _strColumnTitle = source._strColumnTitle;
+        _strDescription = source._strDescription;
+        _strTitle = source._strTitle;
+    }
+
+    /**
      * Returns the Id
      * 
      * @return The Id

--- a/src/java/fr/paris/lutece/plugins/forms/service/cache/FormsCacheService.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/cache/FormsCacheService.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2002-2023, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.forms.service.cache;
+
+import fr.paris.lutece.plugins.forms.business.ControlType;
+import fr.paris.lutece.plugins.forms.business.Form;
+import fr.paris.lutece.portal.business.event.EventRessourceListener;
+import fr.paris.lutece.portal.business.event.ResourceEvent;
+import fr.paris.lutece.portal.service.cache.AbstractCacheableService;
+import fr.paris.lutece.portal.service.event.ResourceEventManager;
+
+public class FormsCacheService extends AbstractCacheableService implements EventRessourceListener
+{
+
+    private static final String CACHE_NAME = "formsCacheService";
+
+    @Override
+    public void initCache( )
+    {
+        super.initCache( );
+        ResourceEventManager.register( this );
+    }
+
+    @Override
+    public String getName( )
+    {
+        return CACHE_NAME;
+    }
+
+    public String getStepCacheKey( int nStepID )
+    {
+        return new StringBuilder( "Step-id:" ).append( nStepID ).toString( );
+    }
+
+    public String getInitialStepCacheKey( int nIdForm )
+    {
+        return new StringBuilder( "Initial-Step-For-Form-id:" ).append( nIdForm ).toString( );
+    }
+
+    public String getFormCacheKey( int nIdForm )
+    {
+        return new StringBuilder( "Form-id:" ).append( nIdForm ).toString( );
+    }
+
+    public String getFormListCacheKey( )
+    {
+        return "FormList";
+    }
+
+    public String getControlCacheKey( int nIdControl )
+    {
+        return new StringBuilder( "Control-id:" ).append( nIdControl ).toString( );
+    }
+
+    public String getControlByControlTargetAndTypeCacheKey( int nIdControlTarget, ControlType controlType )
+    {
+        return new StringBuilder( "Control-by-Target:" ).append( nIdControlTarget ).append( "-and-Type:" )
+                .append( controlType ).toString( );
+    }
+
+    public String getControlByQuestionAndTypeCacheKey( int nIdQuestion, String strControlType )
+    {
+        return new StringBuilder( "Control-by-Question:" ).append( nIdQuestion ).append( "-and-Type:" )
+                .append( strControlType ).toString( );
+    }
+
+    public String getQuestionCacheKey( int nIdQuestion )
+    {
+        return new StringBuilder( "Question-id:" ).append( nIdQuestion ).toString( );
+    }
+
+    public String getFormDisplayCacheKey( int nIdFormDisplay )
+    {
+        return new StringBuilder( "FormDisplay-id:" ).append( nIdFormDisplay ).toString( );
+    }
+
+    public String getFormDisplayListByParentCacheKey( int nIdStep, int nIdParent )
+    {
+        return new StringBuilder( "FormDisplayList-by-Step:" ).append( nIdStep ).append( "-and-Parent:" )
+                .append( nIdParent ).toString( );
+    }
+
+    public String getGroupCacheKey( int nIdGroup )
+    {
+        return new StringBuilder( "Group-id:" ).append( nIdGroup ).toString( );
+    }
+
+    public String getControlGroupCacheKey( int nIdControlGroup )
+    {
+        return new StringBuilder( "ControlGroup-id:" ).append( nIdControlGroup ).toString( );
+    }
+
+    public String getTransitionsListFromStepCacheKey( int nIdStep )
+    {
+        return new StringBuilder( "TransitionsList-From-Step:" ).append( nIdStep ).toString( );
+    }
+
+    public String getFormMessageByFormCacheKey( int nIdForm )
+    {
+        return new StringBuilder( "FormMessage-by-Form:" ).append( nIdForm ).toString( );
+    }
+
+    @Override
+    public void addedResource( ResourceEvent event )
+    {
+        handleEvent( event );
+    }
+
+    @Override
+    public void deletedResource( ResourceEvent event )
+    {
+        handleEvent( event );
+    }
+
+    @Override
+    public void updatedResource( ResourceEvent event )
+    {
+        handleEvent( event );
+    }
+
+    private void handleEvent( ResourceEvent event )
+    {
+        if ( Form.RESOURCE_TYPE.equals( event.getTypeResource( ) ) )
+        {
+            // FIXME GenericAttributes sends events inside a transaction.
+            // this cache reset should really happen after the transaction
+            // but Lutece lacks TransactionSynchronisation infrastructure
+            resetCache( );
+        }
+    }
+}

--- a/src/sql/plugins/forms/plugin/init_db_forms.sql
+++ b/src/sql/plugins/forms/plugin/init_db_forms.sql
@@ -25,3 +25,12 @@ INSERT INTO core_datastore ( entity_key, entity_value ) VALUES( 'forms.display.f
 
 DELETE FROM core_datastore WHERE entity_key='forms.display.form.csv.separator';
 INSERT INTO core_datastore ( entity_key, entity_value ) VALUES( 'forms.display.form.csv.separator', ';' );
+
+DELETE FROM core_datastore WHERE entity_key='core.cache.status.formsCacheService.enabled';
+INSERT INTO core_datastore VALUES ( 'core.cache.status.formsCacheService.enabled', '1' );
+DELETE FROM core_datastore WHERE entity_key='core.cache.status.formsCacheService.timeToIdleSeconds';
+INSERT INTO core_datastore VALUES ( 'core.cache.status.formsCacheService.timeToIdleSeconds', '86400' );
+DELETE FROM core_datastore WHERE entity_key='core.cache.status.formsCacheService.timeToLiveSeconds';
+INSERT INTO core_datastore VALUES ( 'core.cache.status.formsCacheService.timeToLiveSeconds', '86400' );
+DELETE FROM core_datastore WHERE entity_key='core.cache.status.formsCacheService.overflowToDisk';
+INSERT INTO core_datastore VALUES ( 'core.cache.status.formsCacheService.overflowToDisk', '0' );

--- a/src/sql/plugins/forms/upgrade/update_db_forms-2.4.4-2.4.5.sql
+++ b/src/sql/plugins/forms/upgrade/update_db_forms-2.4.4-2.4.5.sql
@@ -1,0 +1,9 @@
+-- configure forms cache
+DELETE FROM core_datastore WHERE entity_key='core.cache.status.formsCacheService.enabled';
+INSERT INTO core_datastore VALUES ( 'core.cache.status.formsCacheService.enabled', '1' );
+DELETE FROM core_datastore WHERE entity_key='core.cache.status.formsCacheService.timeToIdleSeconds';
+INSERT INTO core_datastore VALUES ( 'core.cache.status.formsCacheService.timeToIdleSeconds', '86400' );
+DELETE FROM core_datastore WHERE entity_key='core.cache.status.formsCacheService.timeToLiveSeconds';
+INSERT INTO core_datastore VALUES ( 'core.cache.status.formsCacheService.timeToLiveSeconds', '86400' );
+DELETE FROM core_datastore WHERE entity_key='core.cache.status.formsCacheService.overflowToDisk';
+INSERT INTO core_datastore VALUES ( 'core.cache.status.formsCacheService.overflowToDisk', '0' );

--- a/src/test/java/fr/paris/lutece/plugins/forms/business/FormBusinessTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/forms/business/FormBusinessTest.java
@@ -36,6 +36,8 @@ package fr.paris.lutece.plugins.forms.business;
 import fr.paris.lutece.test.LuteceTestCase;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This is the business class test for the object Form
@@ -81,6 +83,8 @@ public class FormBusinessTest extends LuteceTestCase
         form.setAvailabilityStartDate( STARTDATE2 );
         form.setAvailabilityEndDate( ENDDATE2 );
         form.setBreadcrumbName( BREADCRUMB2 );
+        form.setActions( new ArrayList<>( ) );
+        form.setCurrentNumberResponse( 1000 );
         FormHome.update( form );
         formStored = FormHome.findByPrimaryKey( form.getId( ) );
         assertEquals( formStored.getTitle( ), form.getTitle( ) );
@@ -88,9 +92,18 @@ public class FormBusinessTest extends LuteceTestCase
         assertEquals( formStored.getAvailabilityStartDate( ), form.getAvailabilityStartDate( ) );
         assertEquals( formStored.getAvailabilityEndDate( ), form.getAvailabilityEndDate( ) );
         assertEquals( formStored.getBreadcrumbName( ), form.getBreadcrumbName( ) );
+        assertNull( formStored.getActions( ) );
+        assertEquals( 0, formStored.getCurrentNumberResponse( ) );
 
         // List test
-        FormHome.getFormList( );
+        formStored.setActions( new ArrayList<>( ) );
+        formStored.setCurrentNumberResponse( 1000 );
+        List<Form> list = FormHome.getFormList( );
+        assertNotNull( list );
+        list.forEach( f -> {
+            assertNull( f.getActions( ) );
+            assertEquals( 0, f.getCurrentNumberResponse( ) );
+        });
 
         // Delete test
         FormHome.remove( form.getId( ) );

--- a/src/test/java/fr/paris/lutece/plugins/forms/business/FormTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/forms/business/FormTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2023, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.forms.business;
+
+import static org.junit.Assert.assertNotEquals;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class FormTest extends LuteceTestCase
+{
+
+    public void testCopy( )
+    {
+        Form orig = new Form( );
+        RandomValueFieldPopulator.randomlyPopulateFields( orig );
+        assertNotNull( orig.getActions( ) );
+        assertNotEquals( 0, orig.getCurrentNumberResponse( ) );
+        Form copy = new Form( orig );
+        assertTrue( EqualsBuilder.reflectionEquals( orig, copy, "_listActions", "_nCurrentNumberResponse" ) );
+        assertNull( copy.getActions( ) );
+        assertEquals( 0, copy.getCurrentNumberResponse( ) );
+    }
+
+}

--- a/src/test/java/fr/paris/lutece/plugins/forms/business/QuestionBusinessTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/forms/business/QuestionBusinessTest.java
@@ -33,6 +33,8 @@
  */
 package fr.paris.lutece.plugins.forms.business;
 
+import java.util.List;
+
 import fr.paris.lutece.test.LuteceTestCase;
 
 /**
@@ -71,14 +73,20 @@ public class QuestionBusinessTest extends LuteceTestCase
         question.setTitle( TITLE2 );
         question.setDescription( DESCRIPTION2 );
         question.setIdEntry( IDENTRY2 );
+        question.setIterationNumber( 1000 );
         QuestionHome.update( question );
         questionStored = QuestionHome.findByPrimaryKey( question.getId( ) );
         assertEquals( questionStored.getTitle( ), question.getTitle( ) );
         assertEquals( questionStored.getDescription( ), question.getDescription( ) );
         assertEquals( questionStored.getIdEntry( ), question.getIdEntry( ) );
+        assertEquals( 0, questionStored.getIterationNumber( ) );
 
         // List test
-        QuestionHome.getQuestionsList( );
+        List<Question> list = QuestionHome.getQuestionsList( );
+        assertNotNull( list );
+        list.forEach( q -> {
+            assertEquals( 0, q.getIterationNumber( ) );
+        });
 
         // Delete test
         QuestionHome.remove( question.getId( ) );

--- a/src/test/java/fr/paris/lutece/plugins/forms/business/QuestionTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/forms/business/QuestionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2023, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.forms.business;
+
+import static org.junit.Assert.assertNotEquals;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+import fr.paris.lutece.test.LuteceTestCase;
+
+public class QuestionTest extends LuteceTestCase
+{
+    public void testCopy( )
+    {
+        Question orig = new Question( );
+        RandomValueFieldPopulator.randomlyPopulateFields( orig );
+        assertNotEquals( 0, orig.getIterationNumber( ) );
+        Question copy = new Question( orig );
+        assertTrue( EqualsBuilder.reflectionEquals( orig, copy, "_nIterationNumber" ) );
+        assertEquals( 0, copy.getIterationNumber( ) );
+    }
+}

--- a/src/test/java/fr/paris/lutece/plugins/forms/business/RandomValueFieldPopulator.java
+++ b/src/test/java/fr/paris/lutece/plugins/forms/business/RandomValueFieldPopulator.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2002-2023, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.forms.business;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.ReflectionUtils.FieldCallback;
+
+public class RandomValueFieldPopulator
+{
+
+    private final static Random random = new Random( );
+    private static final int DATE_WINDOW_MILLIS = 10000;
+
+    public void populate( Object object )
+    {
+        ReflectionUtils.doWithFields( object.getClass( ), new RandomValueFieldSetterCallback( object ) );
+    }
+
+    public static void randomlyPopulateFields( Object object )
+    {
+        new RandomValueFieldPopulator( ).populate( object );
+    }
+
+    private static class RandomValueFieldSetterCallback implements FieldCallback
+    {
+        private Object targetObject;
+
+        public RandomValueFieldSetterCallback( Object targetObject )
+        {
+            this.targetObject = targetObject;
+        }
+
+        @Override
+        public void doWith( Field field ) throws IllegalAccessException
+        {
+            Class<?> fieldType = field.getType( );
+            if ( !Modifier.isFinal( field.getModifiers( ) ) )
+            {
+                Object value = generateRandomValue( fieldType );
+                if ( value != null )
+                {
+                    ReflectionUtils.makeAccessible( field );
+                    field.set( targetObject, value );
+                }
+            }
+        }
+    }
+
+    public static Object generateRandomValue( Class<?> fieldType )
+    {
+        if ( fieldType.equals( String.class ) )
+        {
+            return UUID.randomUUID( ).toString( );
+        }
+        else if ( Date.class.isAssignableFrom( fieldType ) )
+        {
+            return new Date( System.currentTimeMillis( ) - random.nextInt( DATE_WINDOW_MILLIS ) );
+        }
+        else if ( Number.class.isAssignableFrom( fieldType ) )
+        {
+            return random.nextInt( Byte.MAX_VALUE ) + 1;
+        }
+        else if ( fieldType.equals( Integer.TYPE ) )
+        {
+            return random.nextInt( );
+        }
+        else if ( fieldType.equals( Long.TYPE ) )
+        {
+            return random.nextInt( );
+        }
+        else if ( fieldType.equals( Boolean.TYPE ) )
+        {
+            return random.nextBoolean( );
+        }
+        else if ( Enum.class.isAssignableFrom( fieldType ) )
+        {
+            Object[ ] enumValues = fieldType.getEnumConstants( );
+            return enumValues[ random.nextInt( enumValues.length ) ];
+        }
+        else if ( Timestamp.class.isAssignableFrom( fieldType ) )
+        {
+            return new Timestamp( System.currentTimeMillis( ) - random.nextInt( DATE_WINDOW_MILLIS ) );
+        }
+        else if ( List.class.isAssignableFrom( fieldType ) )
+        {
+            return Collections.EMPTY_LIST;
+        }
+        return null;
+    }
+}

--- a/webapp/WEB-INF/conf/plugins/forms_context.xml
+++ b/webapp/WEB-INF/conf/plugins/forms_context.xml
@@ -28,6 +28,9 @@
     
     <!-- Services -->
     <bean id="forms.formDatabaseService" class="fr.paris.lutece.plugins.forms.service.FormDatabaseService" />
+
+	<!-- Cache -->
+	<bean id="forms.cacheService" class="fr.paris.lutece.plugins.forms.service.cache.FormsCacheService" init-method="initCache" />
     
     <!-- Export -->
     <bean id="forms.csvExport" class="fr.paris.lutece.plugins.forms.export.csv.CSVExport">


### PR DESCRIPTION
The structure of a form rarely change when compared to the number of times a form is filled. Displaying a form involves loading a lot of objects from the database, which is costly, especially under load.

Cache ControlGroup, Control, FormDisplay, Form, FormMessage, Group, Question, Step and Transition objects. Enable the cache by default.

Some objects from plugin-genericattributes are indirectly cached by this, but not all. A cache there should be useful.