### PR TITLE
LUT_25281 : Draft - Error when restoring a saved draft

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/service/FormService.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/FormService.java
@@ -474,6 +474,7 @@ public class FormService
         if ( CollectionUtils.isNotEmpty( listFormResponse ) )
         {
             formResponseManager = new FormResponseManager( listFormResponse.get( 0 ) );
+            formResponseManager.setIsResponseLoadedFromBackup(true);
         }
         else
         {

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -33,29 +33,20 @@
  */
 package fr.paris.lutece.plugins.forms.web;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TreeMap;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
+import fr.paris.lutece.plugins.forms.business.*;
+import fr.paris.lutece.plugins.genericattributes.business.ResponseHome;
+import fr.paris.lutece.portal.service.util.AppLogService;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
-import fr.paris.lutece.plugins.forms.business.Form;
-import fr.paris.lutece.plugins.forms.business.FormHome;
-import fr.paris.lutece.plugins.forms.business.FormMessage;
-import fr.paris.lutece.plugins.forms.business.FormMessageHome;
-import fr.paris.lutece.plugins.forms.business.FormQuestionResponse;
-import fr.paris.lutece.plugins.forms.business.FormResponse;
-import fr.paris.lutece.plugins.forms.business.Question;
-import fr.paris.lutece.plugins.forms.business.Step;
-import fr.paris.lutece.plugins.forms.business.StepHome;
 import fr.paris.lutece.plugins.forms.exception.FormNotFoundException;
 import fr.paris.lutece.plugins.forms.exception.MaxFormResponseException;
 import fr.paris.lutece.plugins.forms.exception.QuestionValidationException;
@@ -96,9 +87,10 @@ import fr.paris.lutece.portal.util.mvc.xpage.annotations.Controller;
 import fr.paris.lutece.portal.web.upload.MultipartHttpServletRequest;
 import fr.paris.lutece.portal.web.xpages.XPage;
 import fr.paris.lutece.util.url.UrlItem;
+import org.apache.james.mime4j.dom.datetime.DateTime;
 
 /**
- * 
+ *
  * Controller for form display
  *
  */
@@ -123,16 +115,16 @@ public class FormXPage extends MVCApplication
     // Views
     private static final String VIEW_LIST_FORM = "listForm";
     private static final String VIEW_STEP = "stepView";
-    
+
     // Actions
- 	private static final String ACTION_SAVE_FORM_RESPONSE = "doSaveResponse";
- 	private static final String ACTION_SAVE_STEP = "doSaveStep";
- 	private static final String ACTION_RESET_BACKUP = "doResetBackup";
- 	private static final String ACTION_SAVE_FOR_BACKUP = "doSaveForBackup";
- 	private static final String ACTION_PREVIOUS_STEP = "doReturnStep";
- 	private static final String ACTION_GO_TO_STEP = "doGoToStep";
- 	private static final String ACTION_FORM_RESPONSE_SUMMARY = "formResponseSummary";
- 	private static final String ACTION_SAVE_FORM_RESPONSE_SUMMARY = "doSaveResponseSummary";
+    private static final String ACTION_SAVE_FORM_RESPONSE = "doSaveResponse";
+    private static final String ACTION_SAVE_STEP = "doSaveStep";
+    private static final String ACTION_RESET_BACKUP = "doResetBackup";
+    private static final String ACTION_SAVE_FOR_BACKUP = "doSaveForBackup";
+    private static final String ACTION_PREVIOUS_STEP = "doReturnStep";
+    private static final String ACTION_GO_TO_STEP = "doGoToStep";
+    private static final String ACTION_FORM_RESPONSE_SUMMARY = "formResponseSummary";
+    private static final String ACTION_SAVE_FORM_RESPONSE_SUMMARY = "doSaveResponseSummary";
 
     // Actions
     private static final String ACTION_UPLOAD = "doSynchronousUploadDocument";
@@ -161,10 +153,11 @@ public class FormXPage extends MVCApplication
     private StepDisplayTree _stepDisplayTree;
     private IBreadcrumb _breadcrumb;
     private boolean _bInactiveStateBypassed;
+    private boolean IsRequestComingFromAction = false;
 
     /**
      * Return the default XPage with the list of all available Form
-     * 
+     *
      * @param request
      *            The HttpServletRequest
      * @return the list of all available forms
@@ -196,7 +189,7 @@ public class FormXPage extends MVCApplication
     }
 
     /**
-     * 
+     *
      * @param form
      *            the given Form
      * @param request
@@ -220,7 +213,7 @@ public class FormXPage extends MVCApplication
 
     /**
      * check if authentification
-     * 
+     *
      * @param form
      *            Form
      * @param request
@@ -260,11 +253,11 @@ public class FormXPage extends MVCApplication
     }
 
     /**
-     * 
+     *
      * @param request
      *            The Http request
      * @return the XPage
-     * 
+     *
      * @throws SiteMessageException
      *             Exception
      * @throws UserNotSignedException
@@ -295,16 +288,16 @@ public class FormXPage extends MVCApplication
 
         Form form = FormHome.findByPrimaryKey( _currentStep.getIdForm( ) );
         checkAuthentication( form, request );
-        	
+
         LuteceUser user = SecurityService.getInstance( ).getRegisteredUser( request );
 
         if ( user != null && !(FormsResponseUtils.checkIfUserResponseForm( form, user.getName( ) ) ) )
         {
-           	SiteMessageService.setMessage( request, MESSAGE_ERROR_NOT_RESPONSE_AGAIN_FORM, SiteMessage.TYPE_ERROR );
+            SiteMessageService.setMessage( request, MESSAGE_ERROR_NOT_RESPONSE_AGAIN_FORM, SiteMessage.TYPE_ERROR );
         }
         if ( !(FormsResponseUtils.checkNumberMaxResponseForm( form ) ) )
         {
-           	SiteMessageService.setMessage( request, FormsConstants.MESSAGE_ERROR_NUMBER_MAX_RESPONSE_FORM, SiteMessage.TYPE_ERROR );
+            SiteMessageService.setMessage( request, FormsConstants.MESSAGE_ERROR_NUMBER_MAX_RESPONSE_FORM, SiteMessage.TYPE_ERROR );
         }
 
         String strTitleForm = I18nService.getLocalizedString( FormsConstants.MESSAGE_STEP_TITLE, new String [ ] {
@@ -319,16 +312,18 @@ public class FormXPage extends MVCApplication
             {
                 _breadcrumb = SpringContextService.getBean( form.getBreadcrumbName( ) );
             }
-
+            if(_formResponseManager != null && !_formResponseManager.getIsBackupResponseAlreadyInitiated() && _formResponseManager.getIsResponseLoadedFromBackup()) {
+                _formResponseManager.setBackupResponseAlreadyInitiated(true);
+            }
             initFormResponseManager( request, form );
             if ( _formResponseManager.getFormResponse( ).isFromSave( ) )
             {
-            	String strActionNextStep = request.getParameter( "action_" + ACTION_SAVE_STEP );
-            	if (strActionNextStep == null)
-            	{
-            		_currentStep = _formResponseManager.getCurrentStep( );
-                	_stepDisplayTree = new StepDisplayTree( _currentStep.getId( ), _formResponseManager.getFormResponse( ) );
-            	}
+                String strActionNextStep = request.getParameter( "action_" + ACTION_SAVE_STEP );
+                if (strActionNextStep == null && _formResponseManager.getCurrentStep() != null) {
+
+                    _currentStep = _formResponseManager.getCurrentStep( );
+                    _stepDisplayTree = new StepDisplayTree( _currentStep.getId( ), _formResponseManager.getFormResponse( ) );
+                }
                 Object [ ] args = {
                         _formResponseManager.getFormResponseUpdateDate(),
                 };
@@ -338,7 +333,9 @@ public class FormXPage extends MVCApplication
             if ( _stepDisplayTree == null || _currentStep.getId( ) != _stepDisplayTree.getStep( ).getId( ) )
             {
                 _stepDisplayTree = new StepDisplayTree( _currentStep.getId( ), _formResponseManager.getFormResponse( ) );
-                _formResponseManager.add( _currentStep );
+                if(!_formResponseManager.getValidatedSteps().contains(_currentStep.getId())) {
+                    _formResponseManager.add(_currentStep);
+                }
             }
 
             if ( !_formResponseManager.getFormResponse( ).isFromSave( ) && !bypassInactiveState( form, request ) )
@@ -350,7 +347,7 @@ public class FormXPage extends MVCApplication
                     return accessControlPage;
                 }
             }
-               
+
             getFormStepModel( form, request, model );
         }
         else
@@ -364,7 +361,7 @@ public class FormXPage extends MVCApplication
                 SiteMessageService.setMessage( request, FormsConstants.MESSAGE_ERROR_INACTIVE_FORM, SiteMessage.TYPE_ERROR );
             }
         }
-
+        IsRequestComingFromAction = false;
         XPage xPage = getXPage( TEMPLATE_VIEW_STEP, getLocale( request ), model );
         xPage.setTitle( strTitleForm );
         xPage.setPathLabel( strPathForm );
@@ -374,7 +371,7 @@ public class FormXPage extends MVCApplication
 
     /**
      * Does the request contain parameters to bypass the inactive state of the form
-     * 
+     *
      * @param form
      *            the forme
      * @param request
@@ -405,9 +402,9 @@ public class FormXPage extends MVCApplication
             return false;
         }
         long lBypassDuration = AppPropertiesService.getPropertyLong( FormsConstants.PROPERTY_INACTIVE_BYPASS_DURATION_MILLISECONDS, 1000L * 60 * 30 ); // Half
-                                                                                                                                                       // hour
-                                                                                                                                                       // in
-                                                                                                                                                       // milliseconds
+        // hour
+        // in
+        // milliseconds
         if ( timestampAge <= lBypassDuration )
         {
             _bInactiveStateBypassed = true;
@@ -442,18 +439,19 @@ public class FormXPage extends MVCApplication
     }
 
     /**
-     * 
+     *
      * @param request
      *            The Http request
      * @return the XPage
-     * 
+     *
      * @throws SiteMessageException
      *             Exception
-     * @throws UserNotSignedException 
+     * @throws UserNotSignedException
      */
     @Action( value = ACTION_PREVIOUS_STEP )
     public synchronized XPage doReturnStep( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException
     {
+        IsRequestComingFromAction = true;
         boolean bSessionLost = isSessionLost( );
         try
         {
@@ -466,38 +464,48 @@ public class FormXPage extends MVCApplication
         if ( bSessionLost )
         {
             addWarning( MESSAGE_WARNING_LOST_SESSION, getLocale( request ) );
+            _currentStep = _formResponseManager.getCurrentStep( );
             return  getStepView(  request );
         }
         try
         {
-            FormsResponseUtils.fillResponseManagerWithResponses( request, false, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
+            // The condition below : We don't want to fill the FormResponseManager when just logged in with response made when user wasn't logged in
+            //for exemple in case you are at step 2, you log in and you have to go back to step 1 that you already saved in backup
+            if(_formResponseManager.getIsBackupResponseAlreadyInitiated() && _formResponseManager.getIsResponseLoadedFromBackup()
+                    || !_formResponseManager.getIsResponseLoadedFromBackup() && _formResponseManager.getFormResponse().getCreation() != null) {
+                FormsResponseUtils.fillResponseManagerWithResponses(request, false, _formResponseManager, _stepDisplayTree.getQuestions(), false);
+            }
         }
         catch( QuestionValidationException exception )
         {
             return getStepView(  request );
         }
-        _formResponseManager.popStep( );
-
-        _currentStep = _formResponseManager.getCurrentStep( );
-
-        _stepDisplayTree = new StepDisplayTree( _currentStep.getId( ), _formResponseManager.getFormResponse( ) );
+        _formResponseManager.popStep();
+        _currentStep = _formResponseManager.getCurrentStep();
+        try {
+            _stepDisplayTree = new StepDisplayTree(_currentStep.getId(), _formResponseManager.getFormResponse());
+        } catch (Exception e) {
+            return getStepView(  request );
+        }
 
         return  getStepView(  request );
     }
 
     /**
-     * 
+     *
      * @param request
      *            The Http request
      * @return the XPage
-     * 
+     *
      * @throws SiteMessageException
      *             Exception
-     * @throws UserNotSignedException 
+     * @throws UserNotSignedException
      */
     @Action( value = ACTION_GO_TO_STEP )
     public synchronized XPage doGoToStep( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException
     {
+        IsRequestComingFromAction = true;
+
         boolean bSessionLost = isSessionLost( );
 
         try
@@ -506,7 +514,7 @@ public class FormXPage extends MVCApplication
         }
         catch( FormNotFoundException e )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         if ( bSessionLost )
@@ -517,7 +525,7 @@ public class FormXPage extends MVCApplication
 
         try
         {
-        	FormsResponseUtils.fillResponseManagerWithResponses( request, false, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
+            FormsResponseUtils.fillResponseManagerWithResponses( request, false, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
         }
         catch( QuestionValidationException e )
         {
@@ -535,17 +543,18 @@ public class FormXPage extends MVCApplication
 
     /**
      * Gives the summary page
-     * 
+     *
      * @param request
      *            The request
      * @return the summary page
      * @throws SiteMessageException
      *             if there is an error during the page generation
-     * @throws UserNotSignedException 
+     * @throws UserNotSignedException
      */
     @Action( value = ACTION_FORM_RESPONSE_SUMMARY )
     public synchronized XPage doFormResponseSummary( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException
     {
+        IsRequestComingFromAction = true;
         Form form = null;
         try
         {
@@ -604,7 +613,7 @@ public class FormXPage extends MVCApplication
 
     /**
      * Builds the model for the summary page
-     * 
+     *
      * @param request
      *            the request
      * @return the model
@@ -626,11 +635,11 @@ public class FormXPage extends MVCApplication
     }
 
     /**
-     * 
+     *
      * @param request
      *            The Http request
      * @return the XPage
-     * 
+     *
      * @throws SiteMessageException
      *             Exception
      * @throws UserNotSignedException
@@ -640,6 +649,7 @@ public class FormXPage extends MVCApplication
     @Action( value = ACTION_SAVE_FORM_RESPONSE )
     public synchronized XPage doSaveFormResponse( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException, AccessDeniedException
     {
+        IsRequestComingFromAction = true;
         // CSRF Token control
         if ( !SecurityTokenService.getInstance( ).validate( request, ACTION_SAVE_FORM_RESPONSE ) )
         {
@@ -665,18 +675,18 @@ public class FormXPage extends MVCApplication
         }
         catch( FormNotFoundException | QuestionValidationException exception )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         return doSaveResponse( request, form );
     }
 
     /**
-     * 
+     *
      * @param request
      *            The Http request
      * @return the XPage
-     * 
+     *
      * @throws SiteMessageException
      *             Exception
      * @throws UserNotSignedException
@@ -686,6 +696,7 @@ public class FormXPage extends MVCApplication
     @Action( value = ACTION_SAVE_FORM_RESPONSE_SUMMARY )
     public synchronized XPage doSaveFormResponseSummary( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException, AccessDeniedException
     {
+        IsRequestComingFromAction = true;
         // CSRF Token control
         if ( !SecurityTokenService.getInstance( ).validate( request, ACTION_SAVE_FORM_RESPONSE ) )
         {
@@ -711,7 +722,7 @@ public class FormXPage extends MVCApplication
         }
         catch( FormNotFoundException exception )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         return doSaveResponse( request, form );
@@ -753,7 +764,7 @@ public class FormXPage extends MVCApplication
         }
         else
         {
-        	 return redirect( request, strBackUrl );
+            return redirect( request, strBackUrl );
         }
 
         model.put( FormsConstants.PARAMETER_BACK_URL, strBackUrl );
@@ -767,7 +778,7 @@ public class FormXPage extends MVCApplication
 
     /**
      * Finds the form from the specified request
-     * 
+     *
      * @param request
      *            the request
      * @return the found form, or {@code null} if not found
@@ -820,7 +831,7 @@ public class FormXPage extends MVCApplication
     }
 
     /**
-     * 
+     *
      * @param form
      *            The Form
      * @param bIsEndMessageDisplayed
@@ -839,22 +850,22 @@ public class FormXPage extends MVCApplication
 
             if ( form.isAuthentificationNeeded( ) )
             {
-            	url= bIsEndMessageDisplayed? new UrlItem( AppPathService.getPortalUrl( ) ):new UrlItem( "" );
+                url= bIsEndMessageDisplayed? new UrlItem( AppPathService.getPortalUrl( ) ):new UrlItem( "" );
                 url.addParameter( MVCUtils.PARAMETER_PAGE, FormResponseXPage.XPAGE_NAME );
                 url.addParameter( MVCUtils.PARAMETER_VIEW, FormResponseXPage.VIEW_FORM_RESPONSE );
                 url.addParameter( FormsConstants.PARAMETER_ID_RESPONSE, nIdFormResponse );
-                url.addParameter( FormsConstants.PARAMETER_ACTION_SUCCESS, "true" );     
+                url.addParameter( FormsConstants.PARAMETER_ACTION_SUCCESS, "true" );
 
             }
             else
-                if ( bIsEndMessageDisplayed )
-                {
-                    url = new UrlItem( getViewFullUrl( VIEW_STEP ) );
-                }
-                else
-                {
-                    url = new UrlItem( getViewUrl( VIEW_STEP ) );
-                }
+            if ( bIsEndMessageDisplayed )
+            {
+                url = new UrlItem( getViewFullUrl( VIEW_STEP ) );
+            }
+            else
+            {
+                url = new UrlItem( getViewUrl( VIEW_STEP ) );
+            }
 
             url.addParameter( FormsConstants.PARAMETER_ID_FORM, form.getId( ) );
 
@@ -863,11 +874,11 @@ public class FormXPage extends MVCApplication
     }
 
     /**
-     * 
+     *
      * @param request
      *            The Http request
      * @return the XPage
-     * 
+     *
      * @throws SiteMessageException
      *             Exception
      * @throws UserNotSignedException
@@ -880,7 +891,11 @@ public class FormXPage extends MVCApplication
         // CSRF Token control
         if ( !SecurityTokenService.getInstance( ).validate( request, ACTION_SAVE_FORM_RESPONSE ) )
         {
-            throw new AccessDeniedException( MESSAGE_ERROR_TOKEN );
+            // if you go to step 2, then you log in (as you didn't save any backup), the token is invalided
+            // why are we here as we didn't try to save any backup ? So instead of throwing the error, we redirect.
+            AppLogService.error("FormXPage l 897 : " + MESSAGE_ERROR_TOKEN );
+            _currentStep = StepHome.findByPrimaryKey(Integer.parseInt(request.getParameter(FormsConstants.PARAMETER_ID_STEP)));
+            return getStepView(  request );
         }
 
         try
@@ -892,8 +907,10 @@ public class FormXPage extends MVCApplication
                 addWarning( MESSAGE_WARNING_LOST_SESSION, getLocale( request ) );
                 return getStepView(  request );
             }
+            if(_formResponseManager.getCurrentStep() == null) {
+                _formResponseManager.add(StepHome.getInitialStep(form.getId()));
+            }
             FormsResponseUtils.fillResponseManagerWithResponses( request, true, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
-
             boolean needValidation = _currentStep.isInitial( ) && form.isCaptchaStepInitial( );
             if ( isCaptchaKO( request, needValidation ) )
             {
@@ -903,7 +920,7 @@ public class FormXPage extends MVCApplication
         }
         catch( FormNotFoundException | QuestionValidationException exception )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         List<String> errorList = new ArrayList<>( );
@@ -917,6 +934,7 @@ public class FormXPage extends MVCApplication
                     errorList.stream( ).collect( Collectors.joining( ) )
             }, null, null, null, SiteMessage.TYPE_ERROR, null, getViewFullUrl( VIEW_STEP ) );
         }
+        IsRequestComingFromAction = true;
         return getStepView(  request );
     }
 
@@ -930,11 +948,11 @@ public class FormXPage extends MVCApplication
     }
 
     /**
-     * 
+     *
      * @param request
      *            The Http request
      * @return the XPage
-     * 
+     *
      * @throws SiteMessageException
      *             Exception
      * @throws UserNotSignedException
@@ -944,6 +962,7 @@ public class FormXPage extends MVCApplication
     @Action( value = ACTION_SAVE_FOR_BACKUP )
     public synchronized XPage doSaveForBackup( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException, AccessDeniedException
     {
+        IsRequestComingFromAction = true;
         // CSRF Token control
         if ( !SecurityTokenService.getInstance( ).validate( request, ACTION_SAVE_FORM_RESPONSE ) )
         {
@@ -964,37 +983,41 @@ public class FormXPage extends MVCApplication
         }
         catch( FormNotFoundException exception )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         checkAuthentication( form, request );
-
+        if(_formResponseManager.getCurrentStep() == null) {
+            _formResponseManager.add(StepHome.getInitialStep(form.getId()));
+        }
         try
         {
-        	FormsResponseUtils.fillResponseManagerWithResponses( request, false, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
+            FormsResponseUtils.fillResponseManagerWithResponses( request, false, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
         }
         catch( QuestionValidationException e )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         LuteceUser user = SecurityService.getInstance( ).getRegisteredUser( request );
-
         FormResponse formResponse = _formResponseManager.getFormResponse( );
         formResponse.setGuid( user.getName( ) );
+        formResponse.setUpdateStatus(Timestamp.valueOf(LocalDateTime.now()));
 
         _formService.saveFormForBackup( formResponse );
+        _formResponseManager.setFormResponseUpdateDate( formResponse.getUpdateStatus( ) );
+        _formResponseManager.setIsResponseLoadedFromBackup(false);
 
         return getStepView(  request );
     }
 
     /**
      * Removes Backup
-     * 
+     *
      * @param request
      *            The Http request
      * @return the XPage
-     * 
+     *
      * @throws SiteMessageException
      *             Exception
      * @throws UserNotSignedException
@@ -1004,10 +1027,12 @@ public class FormXPage extends MVCApplication
     @Action( value = ACTION_RESET_BACKUP )
     public synchronized XPage doResetBackup( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException, AccessDeniedException
     {
+        IsRequestComingFromAction = true;
         // CSRF Token control
         if ( !SecurityTokenService.getInstance( ).validate( request, ACTION_SAVE_FORM_RESPONSE ) )
         {
-            throw new AccessDeniedException( MESSAGE_ERROR_TOKEN );
+            AppLogService.error( MESSAGE_ERROR_TOKEN );
+            return getStepView(  request );
         }
         Form form = null;
 
@@ -1017,7 +1042,7 @@ public class FormXPage extends MVCApplication
         }
         catch( FormNotFoundException exception )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         checkAuthentication( form, request );
@@ -1025,6 +1050,7 @@ public class FormXPage extends MVCApplication
         FormResponse formResponse = _formResponseManager.getFormResponse( );
 
         _formService.removeFormBackup( formResponse );
+        _formResponseManager = null;
 
         init( form.getId( ) );
 
@@ -1033,7 +1059,7 @@ public class FormXPage extends MVCApplication
 
     /**
      * Adds an iteration
-     * 
+     *
      * @param request
      *            the request
      * @return the XPage
@@ -1045,6 +1071,8 @@ public class FormXPage extends MVCApplication
     @Action( value = ACTION_ADD_ITERATION )
     public synchronized XPage doAddIteration( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException
     {
+        IsRequestComingFromAction = true;
+
         try
         {
             boolean bSessionLost = isSessionLost( );
@@ -1059,7 +1087,7 @@ public class FormXPage extends MVCApplication
         }
         catch( FormNotFoundException | QuestionValidationException exception )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         int nIdGroup = NumberUtils.toInt( request.getParameter( FormsConstants.PARAMETER_ACTION_PREFIX + ACTION_ADD_ITERATION ),
@@ -1075,7 +1103,7 @@ public class FormXPage extends MVCApplication
 
     /**
      * Remove an iteration
-     * 
+     *
      * @param request
      *            the request
      * @return the XPage
@@ -1087,6 +1115,8 @@ public class FormXPage extends MVCApplication
     @Action( value = ACTION_REMOVE_ITERATION )
     public synchronized XPage doRemoveIteration( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException
     {
+        IsRequestComingFromAction = true;
+
         try
         {
             boolean bSessionLost = isSessionLost( );
@@ -1100,7 +1130,7 @@ public class FormXPage extends MVCApplication
         }
         catch( FormNotFoundException | QuestionValidationException exception )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         String strIterationInfo = request.getParameter( FormsConstants.PARAMETER_ACTION_PREFIX + ACTION_REMOVE_ITERATION );
@@ -1129,6 +1159,7 @@ public class FormXPage extends MVCApplication
     @Action( value = ACTION_UPLOAD )
     public synchronized XPage doSynchronousUploadDocument( HttpServletRequest request ) throws SiteMessageException, UserNotSignedException
     {
+        IsRequestComingFromAction = true;
 
         boolean bSessionLost = isSessionLost( );
         if ( bSessionLost )
@@ -1160,12 +1191,12 @@ public class FormXPage extends MVCApplication
         try
         {
 
-        	FormsResponseUtils.fillResponseManagerWithResponses( wrappedRequest, false, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
+            FormsResponseUtils.fillResponseManagerWithResponses( wrappedRequest, false, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
 
         }
         catch( QuestionValidationException exception )
         {
-        	return getStepView(  request );
+            return getStepView(  request );
         }
 
         if ( isUpload )
@@ -1201,23 +1232,23 @@ public class FormXPage extends MVCApplication
 
             // if the entry type is Automatic file Reading, we fill the form responses question with ocr values readed
             else
-                if ( EntryTypeAutomaticFileReading.fill( listQuestionStep, listFormQuestionResponse, wrappedRequest ) )
-                {
+            if ( EntryTypeAutomaticFileReading.fill( listQuestionStep, listFormQuestionResponse, wrappedRequest ) )
+            {
 
-                    _formResponseManager.addResponses( listFormQuestionResponse );
-                }
+                _formResponseManager.addResponses( listFormQuestionResponse );
+            }
         }
 
         return getStepView(  request );
     }
-   
+
     private void initFormResponseManager( HttpServletRequest request, Form form )
     {
         LuteceUser user = SecurityService.getInstance( ).getRegisteredUser( request );
 
-        if ( _formResponseManager == null )
+        if ( _formResponseManager == null || !_formResponseManager.getIsResponseLoadedFromBackup() && !IsRequestComingFromAction)
         {
-            if ( user != null )
+            if ( user != null  && form.isBackupEnabled() )
             {
                 _formResponseManager = _formService.createFormResponseManagerFromBackUp( form, user.getName( ) );
             }
@@ -1230,7 +1261,7 @@ public class FormXPage extends MVCApplication
 
     /**
      * save the response of form
-     * 
+     *
      * @param form
      *            the form
      * @param request
@@ -1250,16 +1281,16 @@ public class FormXPage extends MVCApplication
             LuteceUser user = SecurityService.getInstance( ).getRegisteredUser( request );
             formResponse.setGuid( user.getName( ) );
         }
-        
-        try 
-        {	
-        	_formService.saveForm( form, formResponse );
+
+        try
+        {
+            _formService.saveForm( form, formResponse );
         }
         catch( MaxFormResponseException e)
-        {	
+        {
             SiteMessageService.setMessage( request, FormsConstants.MESSAGE_ERROR_NUMBER_MAX_RESPONSE_FORM, SiteMessage.TYPE_ERROR );
         }
-        
+
         AccessControlService.getInstance( ).cleanSessionData( request, form.getId( ), Form.RESOURCE_TYPE );
 
         _formService.processFormAction( form, formResponse );
@@ -1280,7 +1311,7 @@ public class FormXPage extends MVCApplication
 
     /**
      * initialize the object
-     * 
+     *
      * @param nIdForm
      *            id form
      */
@@ -1294,8 +1325,8 @@ public class FormXPage extends MVCApplication
 
     /**
      * ckeck if the session has expired
-     * 
-     * 
+     *
+     *
      */
     private boolean isSessionLost( )
     {

--- a/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_step.html
+++ b/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_step.html
@@ -1,48 +1,49 @@
 <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title">${step.title}</h3>
+        <h3 class="panel-title">${step.title}</h3>
     </div>
     <div id="step-content" class="panel-body">
-    ${stepContent}
-    <#if display_captcha>${captcha}</#if>
-    </div>
-  <div class="panel-footer">
-  	<input type="hidden" name="token" value = "${token}">
-	<input name="page" value="forms" type="hidden">
-	<input name="id_form" value="${step.idForm}" type="hidden">
-	<#if !step.initial><button class="btn btn-primary btn-sm" name="action_doReturnStep"  type="submit" >#i18n{forms.step.previous}</button></#if>
-	<#if step.final>
-      <#if form.displaySummary >
-        <button class="btn btn-primary btn-sm" name="action_formResponseSummary"  type="submit">#i18n{forms.step.see.summary}</button>
-      <#else>
-      	<#assign label_button="#i18n{forms.step.save}" />
-      	<#if form.labelFinalButton?has_content>
-      		<#assign label_button=form.labelFinalButton />
-      	</#if>
-        <button class="btn btn-primary btn-sm" name="action_doSaveResponse"  type="submit">${label_button}</button>
-      </#if>
-	<#else>
-	  <button class="btn btn-primary btn-sm" name="action_doSaveStep"  type="submit">#i18n{forms.step.next}</button>
-	</#if>
-	<#if user?? && form.backupEnabled>
-		<button class="btn btn-info btn-sm pull-right" name="action_doResetBackup"  type="submit" >#i18n{forms.step.resetResponse}</button>
-		<button class="btn btn-info btn-sm pull-right" name="action_doSaveForBackup"  type="submit" >#i18n{forms.step.saveResponse}</button>
-    </#if>
-  </div>
+        ${stepContent}
+        <#if display_captcha>${captcha}</#if>
+</div>
+<div class="panel-footer">
+    <input type="hidden" name="token" value = "${token}">
+    <input name="page" value="forms" type="hidden">
+    <input name="id_form" value="${step.idForm}" type="hidden">
+    <input name="id_step" value="${step.id}" type="hidden">
+    <#if !step.initial><button class="btn btn-primary btn-sm" name="action_doReturnStep"  type="submit" >#i18n{forms.step.previous}</button></#if>
+<#if step.final>
+<#if form.displaySummary >
+<button class="btn btn-primary btn-sm" name="action_formResponseSummary"  type="submit">#i18n{forms.step.see.summary}</button>
+<#else>
+<#assign label_button="#i18n{forms.step.save}" />
+<#if form.labelFinalButton?has_content>
+<#assign label_button=form.labelFinalButton />
+</#if>
+<button class="btn btn-primary btn-sm" name="action_doSaveResponse"  type="submit">${label_button}</button>
+</#if>
+<#else>
+<button class="btn btn-primary btn-sm" name="action_doSaveStep"  type="submit">#i18n{forms.step.next}</button>
+</#if>
+<#if user?? && form.backupEnabled>
+<button class="btn btn-info btn-sm pull-right" name="action_doResetBackup"  type="submit" >#i18n{forms.step.resetResponse}</button>
+<button class="btn btn-info btn-sm pull-right" name="action_doSaveForBackup"  type="submit" >#i18n{forms.step.saveResponse}</button>
+</#if>
+</div>
 </div>
 <script>
-  $( function() {
-     /* Check if step-group has all field hidden due to conditionnal behavior */
-    $(".step-group").each( function(){
-      var count_field = $(this).find( '.form-group').length,
-        count_cond =  $(this).find( 'div[class*="display_field_"]' ).length,
-        count_cond_visible = $(this).find( 'div[class*="display_field_"]:visible' ).length;
-       
-      if( count_field == count_cond &&  count_cond > 0 &&  count_cond_visible==0 ){
-        $(this).toggle();
-        $(this).addClass('step-group-collapsible');
-      }
+    $( function() {
+        /* Check if step-group has all field hidden due to conditionnal behavior */
+        $(".step-group").each( function(){
+            var count_field = $(this).find( '.form-group').length,
+                count_cond =  $(this).find( 'div[class*="display_field_"]' ).length,
+                count_cond_visible = $(this).find( 'div[class*="display_field_"]:visible' ).length;
+
+            if( count_field == count_cond &&  count_cond > 0 &&  count_cond_visible==0 ){
+                $(this).toggle();
+                $(this).addClass('step-group-collapsible');
+            }
+        });
     });
-  });
-  </script>
+</script>
   


### PR DESCRIPTION
LUT_25281 : Draft - Error when restoring a saved draft
https://dev.lutece.paris.fr/bugtracker/issues/25281#change-159799

Access to backup responses, on forms that has the "save backup response" enable and no "mandatory authentication".
The problem was due to the condition FormResponseManager not null (the condition to load backup responses), because if you first go to first go to the page, FormResponseManager intanciates (before user logs in), and doesn't loaded the backup responses.
To make it work, different conditions has been implemented.
Has well, there are some changes with some of the "throw error", that has been change for with AppLogService.error, then a redirect so the view can loaded with the proper datas.

Fixed doSaveForBackup, formResponse updateStatus was null

To test the changes you need to add that dependency :

fr.paris.lutece.plugins
module-mylutece-database
[6.0.4-SNAPSHOT,)
lutece-plugin
Then you can create users and a form that has backup response enable.
Go on the form, fill steps (or not), save back up response, try to retrieve after with an another session ...

