### PR TITLE
LUT-25517

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -969,22 +969,21 @@ public class FormXPage extends MVCApplication
 
         checkAuthentication( form, request );
 
-        try
+        if(form.isBackupEnabled())
         {
-        	FormsResponseUtils.fillResponseManagerWithResponses( request, false, _formResponseManager, _stepDisplayTree.getQuestions( ), false );
+            try {
+                FormsResponseUtils.fillResponseManagerWithResponses(request, false, _formResponseManager, _stepDisplayTree.getQuestions(), false);
+            } catch (QuestionValidationException e) {
+                return getStepView(request);
+            }
+
+            LuteceUser user = SecurityService.getInstance().getRegisteredUser(request);
+
+            FormResponse formResponse = _formResponseManager.getFormResponse();
+            formResponse.setGuid(user.getName());
+
+            _formService.saveFormForBackup(formResponse);
         }
-        catch( QuestionValidationException e )
-        {
-        	return getStepView(  request );
-        }
-
-        LuteceUser user = SecurityService.getInstance( ).getRegisteredUser( request );
-
-        FormResponse formResponse = _formResponseManager.getFormResponse( );
-        formResponse.setGuid( user.getName( ) );
-
-        _formService.saveFormForBackup( formResponse );
-
         return getStepView(  request );
     }
 


### PR DESCRIPTION
The Enable saving of incomplete responses option is always active
https://dev.lutece.paris.fr/bugtracker/issues/25517

It's only a condition adding in FormXpage, around L972 ,"  if(form.isBackupEnabled()) " because this ticket is mostly done in https://github.com/lutece-platform/lutece-form-plugin-forms/pull/269, so this PR can be merged after the pr n°269.
