### PR TITLE
LUT-27605: Use forms' workgroups to restrict their access (and the access to their responses) to users part of the same workgroups

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/business/form/list/FormListFacade.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/form/list/FormListFacade.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.forms.business.form.list;
 
+import fr.paris.lutece.api.user.User;
 import fr.paris.lutece.plugins.forms.business.form.FormItemSortConfig;
 import java.util.Comparator;
 import java.util.List;
@@ -87,5 +88,31 @@ public class FormListFacade
         listFormColumn.sort( Comparator.comparing( IFormColumn::getFormColumnPosition ) );
 
         _formListDAO.populateFormColumns( formPanel, listFormColumn, listFormFilter, nStartIndex, nPageSize, sortConfig );
+    }
+
+    /**
+     * Populate the given FormPanel with the information of the given FormColumns and FormFilters
+     *
+     * @param formPanel
+     *            The FormPanel to populate
+     * @param listFormColumn
+     *            The list of all FormColumn to use to be populated
+     * @param listFormFilter
+     *            The list of FormFilter to use for retrieving the data of the columns to populate
+     * @param nStartIndex
+     *            The start index of doc
+     * @param nPageSize
+     *            The number of docs to load for pagination purpose
+     * @param sortConfig
+     *            The comparator config
+     * @param user
+     *            The current user
+     */
+    public void populateFormColumns( FormPanel formPanel, List<IFormColumn> listFormColumn, List<FormFilter> listFormFilter, int nStartIndex, int nPageSize,
+            FormItemSortConfig sortConfig, User user )
+    {
+        listFormColumn.sort( Comparator.comparing( IFormColumn::getFormColumnPosition ) );
+
+        _formListDAO.populateFormColumns( formPanel, listFormColumn, listFormFilter, nStartIndex, nPageSize, sortConfig, user );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/business/form/list/IFormListDAO.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/form/list/IFormListDAO.java
@@ -34,6 +34,7 @@
 package fr.paris.lutece.plugins.forms.business.form.list;
 
 import fr.paris.lutece.plugins.forms.business.form.FormResponseItem;
+import fr.paris.lutece.api.user.User;
 import fr.paris.lutece.plugins.forms.business.form.FormItemSortConfig;
 import java.util.List;
 
@@ -64,6 +65,27 @@ public interface IFormListDAO
      */
     void populateFormColumns( FormPanel formPanel, List<IFormColumn> listFormColumn, List<FormFilter> listFormFilter, int nStartIndex, int nPageSize,
             FormItemSortConfig sortConfig );
+
+    /**
+     * Populate the FormPanel with the values returned by the SQL query results
+     *
+     * @param formPanel
+     *            The FormPanel used to retrieve the values of the FormColumn
+     * @param listFormColumn
+     *            The list of FormColumn to populate
+     * @param listFormFilter
+     *            The list of FormFilter used for filtering the data to retrieve
+     * @param nStartIndex
+     *            The start index of doc that all will become FormResponseItem
+     * @param nPageSize
+     *            The number of doc to load for pagination purpose
+     * @param sortConfig
+     *            The comparator config
+     * @param user
+     *            The current user
+     */
+    void populateFormColumns( FormPanel formPanel, java.util.List<IFormColumn> listFormColumn, List<FormFilter> listFormFilter, int nStartIndex, int nPageSize,
+            FormItemSortConfig sortConfig, User user );
 
     /**
      * Search the Lucene Index.

--- a/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/IFormPanelInitializer.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/IFormPanelInitializer.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.forms.business.form.panel.initializer;
 
+import fr.paris.lutece.api.user.User;
 import fr.paris.lutece.plugins.forms.business.form.FormParameters;
 import fr.paris.lutece.plugins.forms.business.form.panel.initializer.querypart.IFormPanelInitializerQueryPart;
 import fr.paris.lutece.plugins.forms.web.form.panel.display.initializer.IFormPanelDisplayInitializer;
@@ -63,6 +64,13 @@ public interface IFormPanelInitializer
      * @return
      */
     IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( );
+
+    /**
+     * Get an {@link IFormPanelInitializerQueryPart} associated with this IFormPanelInitializer.
+     * 
+     * @return
+     */
+    IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( User user );
 
     /**
      * Get an {@link IFormPanelDisplayInitializer} associated with this IFormPanelInitializer.

--- a/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/impl/FormPanelFormResponseInitializer.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/impl/FormPanelFormResponseInitializer.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.forms.business.form.panel.initializer.impl;
 
+import fr.paris.lutece.api.user.User;
 import fr.paris.lutece.plugins.forms.business.form.panel.initializer.querypart.IFormPanelInitializerQueryPart;
 import fr.paris.lutece.plugins.forms.business.form.panel.initializer.querypart.impl.FormPanelFormResponseInitializerQueryPart;
 import fr.paris.lutece.plugins.forms.web.form.panel.display.initializer.IFormPanelDisplayInitializer;
@@ -43,6 +44,8 @@ import fr.paris.lutece.plugins.forms.web.form.panel.display.initializer.impl.For
  */
 public class FormPanelFormResponseInitializer extends AbstractFormPanelInitializer
 {
+    public User _user;
+
     @Override
     public IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( )
     {
@@ -53,5 +56,11 @@ public class FormPanelFormResponseInitializer extends AbstractFormPanelInitializ
     public IFormPanelDisplayInitializer getFormPanelDisplayInitializer( )
     {
         return new FormPanelFormResponseDisplayInitializer( );
+    }
+
+    @Override
+    public IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( User user )
+    {
+        return new FormPanelFormResponseInitializerQueryPart( _user );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/impl/FormPanelFormsInitializer.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/impl/FormPanelFormsInitializer.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.forms.business.form.panel.initializer.impl;
 
+import fr.paris.lutece.api.user.User;
 import fr.paris.lutece.plugins.forms.business.form.panel.initializer.querypart.IFormPanelInitializerQueryPart;
 import fr.paris.lutece.plugins.forms.business.form.panel.initializer.querypart.impl.FormPanelFormsInitializerQueryPart;
 import fr.paris.lutece.plugins.forms.web.form.panel.display.initializer.IFormPanelDisplayInitializer;
@@ -47,6 +48,12 @@ public class FormPanelFormsInitializer extends AbstractFormPanelInitializer
     public IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( )
     {
         return new FormPanelFormsInitializerQueryPart( );
+    }
+
+    @Override
+    public IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( User user )
+    {
+        return new FormPanelFormsInitializerQueryPart( user );
     }
 
     @Override

--- a/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/querypart/impl/FormPanelFormResponseInitializerQueryPart.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/querypart/impl/FormPanelFormResponseInitializerQueryPart.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.forms.business.form.panel.initializer.querypart.impl;
 
+import fr.paris.lutece.api.user.User;
 import fr.paris.lutece.plugins.forms.business.form.FormParameters;
 
 /**
@@ -40,6 +41,16 @@ import fr.paris.lutece.plugins.forms.business.form.FormParameters;
  */
 public class FormPanelFormResponseInitializerQueryPart extends AbstractFormPanelInitializerQueryPart
 {
+    public FormPanelFormResponseInitializerQueryPart( User user )
+    {
+        super( );
+    }
+
+    public FormPanelFormResponseInitializerQueryPart( )
+    {
+        super( );
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/querypart/impl/FormPanelFormsInitializerQueryPart.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/querypart/impl/FormPanelFormsInitializerQueryPart.java
@@ -33,8 +33,23 @@
  */
 package fr.paris.lutece.plugins.forms.business.form.panel.initializer.querypart.impl;
 
+import fr.paris.lutece.api.user.User;
+import fr.paris.lutece.plugins.forms.business.Form;
+import fr.paris.lutece.plugins.forms.business.FormHome;
 import fr.paris.lutece.plugins.forms.business.form.FormParameters;
+import fr.paris.lutece.plugins.forms.util.FormsConstants;
+import fr.paris.lutece.portal.service.workgroup.AdminWorkgroupService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 
 /**
  * Implementation of the FormPanelInitializerQueryPart associate to the FormPanelFormsInitializer
@@ -48,6 +63,60 @@ public class FormPanelFormsInitializerQueryPart extends AbstractFormPanelInitial
     {
         super( );
         setFormPanelInitializerSelectQuery( new MatchAllDocsQuery( ) );
+    }
+
+    /**
+     * Constructor used to build a query that selects the Forms that the user can access
+     * 
+     * @param user
+     *            The HTTP user
+     */
+    public FormPanelFormsInitializerQueryPart( User user )
+    {
+        super( );
+        List<Form> listForms = FormHome.getFormList( );
+        listForms = (List<Form>) AdminWorkgroupService.getAuthorizedCollection( listForms, user );
+        List<Integer> listIds = new ArrayList<>( );
+        for ( Form form : listForms )
+        {
+            listIds.add( form.getId( ) );
+        }
+        // sort the list
+        Collections.sort( listIds );
+        List<List<Integer>> listIdsList = new ArrayList<>( );
+        for ( int i = 0; i < listIds.size( ); i++ )
+        {
+            // if there is a gap between the current id and the previous we create a new list
+            if ( i == 0 || listIds.get( i ) != listIds.get( i - 1 ) + 1 )
+            {
+                listIdsList.add( new ArrayList<>( ) );
+            }
+            listIdsList.get( listIdsList.size( ) - 1 ).add( listIds.get( i ) );
+        }
+        List<Query> queries = new ArrayList<>( );
+        if ( !listIdsList.isEmpty( ) && listIdsList.get( 0 ) != null && !listIdsList.get( 0 ).isEmpty( ) )
+        {
+            for ( int i = 0; i < listIdsList.size( ); i++ )
+            {
+                if ( listIdsList.get( i ).size( ) == 1 )
+                {
+                    queries.add( IntPoint.newExactQuery( FormsConstants.PARAMETER_ID_FORM, listIdsList.get( i ).get( 0 ) ) );
+                }
+                else
+                {
+                    queries.add( IntPoint.newRangeQuery( FormsConstants.PARAMETER_ID_FORM, listIdsList.get( i ).get( 0 ),
+                            listIdsList.get( i ).get( listIdsList.get( i ).size( ) - 1 ) ) );
+                }
+            }
+        }
+        Builder builder = new BooleanQuery.Builder( );
+        for ( Query query : queries )
+        {
+            builder.add( query, BooleanClause.Occur.SHOULD );
+        }
+        Query queryForms = builder.build( );
+
+        setFormPanelInitializerSelectQuery( queryForms );
     }
 
     /**

--- a/src/java/fr/paris/lutece/plugins/forms/service/FormsMultiviewAuthorizationService.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/FormsMultiviewAuthorizationService.java
@@ -34,6 +34,7 @@
 package fr.paris.lutece.plugins.forms.service;
 
 import fr.paris.lutece.api.user.User;
+import fr.paris.lutece.plugins.forms.business.Form;
 import fr.paris.lutece.plugins.forms.business.form.FormParameters;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,6 +57,7 @@ import fr.paris.lutece.plugins.forms.business.form.panel.configuration.IFormPane
 import fr.paris.lutece.plugins.forms.util.FormsConstants;
 import fr.paris.lutece.plugins.forms.web.form.FormDisplayFactory;
 import fr.paris.lutece.portal.service.admin.AdminUserService;
+import fr.paris.lutece.portal.service.workgroup.AdminWorkgroupService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -124,6 +126,22 @@ public class FormsMultiviewAuthorizationService implements IFormsMultiviewAuthor
         }
 
         return bIsUserAuthorizedOnFormResponse;
+    }
+
+    /**
+     * Check if the user is authorized to access the form response within workgroup constraints
+     *
+     * @param request
+     *            The request to use to determine if the user can access the details of the given form response
+     * @param form
+     *            The Form
+     * @return true if the user is authorized to access the form response, false otherwise
+     */
+    @Override
+    public boolean isUserAuthorizedOnFormResponseWithinWorkgroup( HttpServletRequest request, Form form )
+    {
+        User user = AdminUserService.getAdminUser( request );
+        return AdminWorkgroupService.isAuthorized( form, user );
     }
 
     /**

--- a/src/java/fr/paris/lutece/plugins/forms/service/IFormsMultiviewAuthorizationService.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/IFormsMultiviewAuthorizationService.java
@@ -35,6 +35,8 @@ package fr.paris.lutece.plugins.forms.service;
 
 import javax.servlet.http.HttpServletRequest;
 
+import fr.paris.lutece.plugins.forms.business.Form;
+
 /**
  * Forms service for managing the authorization on access form response from the multiview page
  */
@@ -51,4 +53,16 @@ public interface IFormsMultiviewAuthorizationService
      * @return the boolean which tell if the connected user is authorized to access the form response or not
      */
     boolean isUserAuthorizedOnFormResponse( HttpServletRequest request, int nIdFormResponse );
+
+    /**
+     * Return the boolean which tells if the connected user is authorized to access the form response details or not, depending on their Workgroup and the
+     * Workgroup of the Form
+     * 
+     * @param request
+     *            The request to use to determine if the user can access the details of the given Form
+     * @param form
+     *            The Form whose Workgroup is compared to the user's one
+     * @return true if the connected user is authorized to access the form response, returns false otherwise
+     */
+    boolean isUserAuthorizedOnFormResponseWithinWorkgroup( HttpServletRequest request, Form form );
 }

--- a/src/java/fr/paris/lutece/plugins/forms/service/MultiviewFormService.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/MultiviewFormService.java
@@ -68,6 +68,8 @@ import fr.paris.lutece.plugins.forms.web.entrytype.IEntryDisplayService;
 import fr.paris.lutece.plugins.forms.web.form.panel.display.IFormPanelDisplay;
 import fr.paris.lutece.portal.service.rbac.RBACService;
 import fr.paris.lutece.portal.service.spring.SpringContextService;
+import fr.paris.lutece.portal.service.workgroup.AdminWorkgroupService;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -119,6 +121,30 @@ public final class MultiviewFormService
     {
         FormListFacade formListFacade = SpringContextService.getBean( FormListFacade.BEAN_NAME );
         formListFacade.populateFormColumns( formPanel, listFormColumn, listFormFilter, nStartIndex, nPageSize, sortConfig );
+    }
+
+    /**
+     * Populate the given FormPanel with the information from the given list of FormColumns and FormFilters
+     *
+     * @param formPanel
+     *            The FormPanel used to retrieve the values of the FormColumns
+     * @param listFormColumn
+     *            The list of all FormColumn to use to be populated
+     * @param listFormFilter
+     *            The list of FormFilter to use for retrieving the data of the columns to populate
+     * @param nStartIndex
+     *            The start index of doc to load
+     * @param nPageSize
+     *            The size of page of docs to load
+     * @param sortConfig
+     *
+     * @param user
+     */
+    public void populateFormColumns( FormPanel formPanel, List<IFormColumn> listFormColumn, List<FormFilter> listFormFilter, int nStartIndex, int nPageSize,
+                                     FormItemSortConfig sortConfig, User user )
+    {
+        FormListFacade formListFacade = SpringContextService.getBean( FormListFacade.BEAN_NAME );
+        formListFacade.populateFormColumns( formPanel, listFormColumn, listFormFilter, nStartIndex, nPageSize, sortConfig, user );
     }
 
     public List<FormResponseItem> searchAllListFormResponseItem( FormPanel formPanel, List<IFormColumn> listFormColumn, List<FormFilter> listFormFilter,
@@ -191,13 +217,13 @@ public final class MultiviewFormService
             }
         }
 
-        // Then add global columns from config questions
-        List<Question> listQuestions = ( nIdForm == null || nIdForm == FormsConstants.DEFAULT_ID_VALUE ) ? QuestionHome.getQuestionsListUncomplete( )
-                : QuestionHome.getListQuestionByIdFormUncomplete( nIdForm );
+        // Get the List of questions the user is authorized to access
+        List<Question> listQuestions = getQuestionListFromAuthorizedForms( nIdForm, user );
 
         // Sort questions by multiview order
         listQuestions.sort( Comparator.comparing( Question::getMultiviewColumnOrder ) );
 
+        // Then add global columns from config questions
         addColumnFromConfig( mapFormColumns, listQuestions, true, locale );
 
         if ( nIdForm != null && nIdForm != FormsConstants.DEFAULT_ID_VALUE )
@@ -257,10 +283,10 @@ public final class MultiviewFormService
             }
         }
 
-        // Then add the global question-based for Filters
-        List<Question> listQuestions = ( nIdForm == null || nIdForm == FormsConstants.DEFAULT_ID_VALUE ) ? QuestionHome.getQuestionsListUncomplete( )
-                : QuestionHome.getListQuestionByIdFormUncomplete( nIdForm );
+        // Get the List of questions the user is authorized to access
+        List<Question> listQuestions = getQuestionListFromAuthorizedForms( nIdForm, user );
 
+        // Then add the global question-based for Filters
         addFilterFromConfig( mapFormFilter, listQuestions, listFormColumn, true, locale );
 
         if ( nIdForm != null && nIdForm != FormsConstants.DEFAULT_ID_VALUE )
@@ -380,5 +406,44 @@ public final class MultiviewFormService
 
             }
         }
+    }
+
+    /**
+     * Get the List of questions from the Forms that are part of the User's workgroups
+     * 
+     * @param nIdForm
+     *            The Form being processed. Can be null or -1 if there are multiple Forms
+     * @param user
+     *            The current User
+     * @return a List of Question objects
+     */
+    private List<Question> getQuestionListFromAuthorizedForms( Integer nIdForm, User user )
+    {
+        List<Question> listQuestions = new ArrayList<>( );
+
+        // Retrieve the authorized List of Forms (same workgroups as the User)
+        List<Form> listForms = FormHome.getFormList( );
+        listForms = (List<Form>) AdminWorkgroupService.getAuthorizedCollection( listForms, user );
+
+        // If there are multiple Forms to check
+        if ( nIdForm == null || nIdForm == FormsConstants.DEFAULT_ID_VALUE )
+        {
+            // Retrieve the questions from all the Forms
+            for ( Form authorizedForm : listForms )
+            {
+                listQuestions.addAll( QuestionHome.getListQuestionByIdFormUncomplete( authorizedForm.getId( ) ) );
+            }
+        }
+        // If only one Form has to be checked
+        else
+        {
+            // If the given Form is part of the authorized Forms
+            if ( listForms.stream( ).anyMatch( form -> form.getId( ) == nIdForm ) )
+            {
+                // Retrieve the List of questions from the specified Form
+                listQuestions = QuestionHome.getListQuestionByIdFormUncomplete( nIdForm );
+            }
+        }
+        return listQuestions;
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/web/admin/MultiviewFormResponseDetailsJspBean.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/admin/MultiviewFormResponseDetailsJspBean.java
@@ -179,6 +179,14 @@ public class MultiviewFormResponseDetailsJspBean extends AbstractJspBean
                 FormsResourceIdService.PERMISSION_VIEW_FORM_RESPONSE, (User) getUser( ) );
         boolean bAuthorizedRecord = _formsMultiviewAuthorizationService.isUserAuthorizedOnFormResponse( request, nIdFormResponse );
 
+        // If the current user is not part of this Form's workgroup then deny them access to the form's responses
+        if ( bAuthorizedRecord )
+        {
+            int nIdForm = formResponse.getFormId( );
+            Form form = FormHome.findByPrimaryKey( nIdForm );
+            bAuthorizedRecord = _formsMultiviewAuthorizationService.isUserAuthorizedOnFormResponseWithinWorkgroup( request, form );
+        }
+
         if ( !bRBACAuthorization || !bAuthorizedRecord )
         {
             throw new AccessDeniedException( MESSAGE_ACCESS_DENIED );

--- a/src/java/fr/paris/lutece/plugins/forms/web/admin/MultiviewFormsJspBean.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/admin/MultiviewFormsJspBean.java
@@ -486,6 +486,8 @@ public class MultiviewFormsJspBean extends AbstractJspBean
         // Retrieve the list of all FormFilter
         List<FormFilter> listFormFilter = _listFormFilterDisplay.stream( ).map( IFormFilterDisplay::getFormFilter ).collect( Collectors.toList( ) );
 
+        User user = (User) AdminUserService.getAdminUser( request );
+
         // Check in filters if the columns list has to be fetch again
         reloadFormColumnList( listFormFilter, request.getLocale( ), (User) AdminUserService.getAdminUser( request ) );
         if ( formSelectedAsChanged( request ) )
@@ -501,7 +503,7 @@ public class MultiviewFormsJspBean extends AbstractJspBean
 
             // Populate the FormColumns from the information of the list of FormResponseItem
             // of the given FormPanel
-            MultiviewFormService.getInstance( ).populateFormColumns( formPanel, _listFormColumn, listFormFilter, nIndexStart, nPageSize, sortConfig );
+            MultiviewFormService.getInstance( ).populateFormColumns( formPanel, _listFormColumn, listFormFilter, nIndexStart, nPageSize, sortConfig, user );
 
             // Associate for each FormColumnDisplay its FormColumnValues if the panel is
             // active

--- a/src/java/fr/paris/lutece/plugins/forms/web/form/filter/display/impl/FormFilterDisplayForms.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/form/filter/display/impl/FormFilterDisplayForms.java
@@ -54,6 +54,7 @@ import fr.paris.lutece.portal.business.user.AdminUser;
 import fr.paris.lutece.portal.service.admin.AdminUserService;
 import fr.paris.lutece.portal.service.rbac.RBACService;
 import fr.paris.lutece.portal.service.template.AppTemplateService;
+import fr.paris.lutece.portal.service.workgroup.AdminWorkgroupService;
 import fr.paris.lutece.util.ReferenceList;
 import fr.paris.lutece.util.html.HtmlTemplate;
 
@@ -134,6 +135,28 @@ public class FormFilterDisplayForms extends AbstractFormFilterDisplay
         AdminUser user = AdminUserService.getAdminUser( request );
         ReferenceList refListForms = createReferenceList( user );
         String strTemplateResult = StringUtils.EMPTY;
+
+        List <Form> formList = getFormsList( );
+        formList = (List<Form>) AdminWorkgroupService.getAuthorizedCollection( formList, user );
+        // check if refListForms.code is in formList
+        for (int i = 0; i < refListForms.size(); i++)
+        {
+            boolean found = false;
+            Integer code = Integer.parseInt(refListForms.get(i).getCode());
+            for (int j = 0; j < formList.size(); j++)
+            {
+                if (code.equals(formList.get(j).getId()))
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+            {
+                refListForms.remove(i);
+                i--;
+            }
+        }
 
         if ( refListForms.size( ) == 2 )
         {

--- a/src/test/java/fr/paris/lutece/plugins/forms/business/form/list/FormListDAOMock.java
+++ b/src/test/java/fr/paris/lutece/plugins/forms/business/form/list/FormListDAOMock.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import fr.paris.lutece.plugins.forms.business.form.FormResponseItem;
+import fr.paris.lutece.api.user.User;
 import fr.paris.lutece.plugins.forms.business.form.FormItemSortConfig;
 import fr.paris.lutece.plugins.forms.business.form.column.IFormColumn;
 import fr.paris.lutece.plugins.forms.business.form.filter.FormFilter;
@@ -67,6 +68,23 @@ public class FormListDAOMock implements IFormListDAO
     @Override
     public void populateFormColumns( FormPanel formPanel, List<IFormColumn> listFormColumn, List<FormFilter> listFormFilter, int nStartIndex, int nPageSize,
             FormItemSortConfig sortConfig )
+    {
+        List<FormResponseItem> listFormResponseItem = new ArrayList<>( );
+
+        for ( Integer nIdFormResponse : _listIdAuthorizedFormResponse )
+        {
+            FormResponseItem formResponseItem = new FormResponseItem( );
+            formResponseItem.setIdFormResponse( nIdFormResponse );
+
+            listFormResponseItem.add( formResponseItem );
+        }
+
+        formPanel.setFormResponseItemList( listFormResponseItem );
+    }
+
+    @Override
+    public void populateFormColumns( FormPanel formPanel, List<IFormColumn> listFormColumn, List<FormFilter> listFormFilter, int nStartIndex, int nPageSize,
+            FormItemSortConfig sortConfig, User user )
     {
         List<FormResponseItem> listFormResponseItem = new ArrayList<>( );
 

--- a/src/test/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/impl/FormPanelFormResponseInitializerMock.java
+++ b/src/test/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/impl/FormPanelFormResponseInitializerMock.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.forms.business.form.panel.initializer.impl;
 
+import fr.paris.lutece.api.user.User;
 import fr.paris.lutece.plugins.forms.business.form.FormParameters;
 import fr.paris.lutece.plugins.forms.business.form.panel.initializer.IFormPanelInitializer;
 import fr.paris.lutece.plugins.forms.business.form.panel.initializer.querypart.IFormPanelInitializerQueryPart;
@@ -66,6 +67,12 @@ public class FormPanelFormResponseInitializerMock implements IFormPanelInitializ
 
     @Override
     public IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( )
+    {
+        return null;
+    }
+
+    @Override
+    public IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( User user )
     {
         return null;
     }

--- a/src/test/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/impl/FormPanelFormsInitializerMock.java
+++ b/src/test/java/fr/paris/lutece/plugins/forms/business/form/panel/initializer/impl/FormPanelFormsInitializerMock.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.forms.business.form.panel.initializer.impl;
 
+import fr.paris.lutece.api.user.User;
 import fr.paris.lutece.plugins.forms.business.form.FormParameters;
 import fr.paris.lutece.plugins.forms.business.form.panel.initializer.IFormPanelInitializer;
 import fr.paris.lutece.plugins.forms.business.form.panel.initializer.querypart.IFormPanelInitializerQueryPart;
@@ -66,6 +67,12 @@ public class FormPanelFormsInitializerMock implements IFormPanelInitializer
 
     @Override
     public IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( )
+    {
+        return null;
+    }
+
+    @Override
+    public IFormPanelInitializerQueryPart getIFormPanelInitializerQueryPart( User user )
     {
         return null;
     }


### PR DESCRIPTION
1. This Pull Request contains the same code changes suggested in the following PR:

    - https://github.com/lutece-platform/lutece-form-plugin-forms/pull/335

2. It does add one extra method in the `MultiviewFormService.java`:

``` Java 
List<Question> getQuestionListFromAuthorizedForms( Integer nIdForm, User user )
```

This method is used to only retrieve the Questions from the Forms that the user is allowed to access (same Workgroup).

It can be useful if we don't want to display the **search filters** or **column names** of unauthorized Forms in the multiview responses page (`jsp/admin/plugins/forms/MultiviewForms.jsp`).