### PR TITLE
LUT-29256: Remove unnecessary admin feature

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/web/admin/FormExportJspBean.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/admin/FormExportJspBean.java
@@ -97,7 +97,6 @@ public class FormExportJspBean extends AbstractJspBean
     // Parameters
     private static final String PARAMETER_EXPORT_CONFIG = "export_config";
     private static final String PARAMETER_ID_CONFIG = "id_config";
-    private static final String PARAMETER_ID_QUESTION = "id_question";
     private static final String PARAMETER_ACTIVE_TAB_PANNEL_2 = "activeTabPannel2";
     private static final String MESSAGE_CONFIRM_REMOVE_EXPORT_CONFIG = "forms.modify_form.message.confirmRemoveExportConfig";
     private static final String PARAMETER_EXPORT_ALL = "export_all";

--- a/webapp/WEB-INF/plugins/forms.xml
+++ b/webapp/WEB-INF/plugins/forms.xml
@@ -42,14 +42,6 @@
             <feature-icon-url/>
         </admin-feature>
         <admin-feature>
-            <feature-id>FORMS_QUESTION_EXPORT_ORDER_MANAGEMENT</feature-id>
-            <feature-title>forms.adminFeature.manageFormsQuestions.name</feature-title>
-            <feature-description>forms.adminFeature.manageFormsQuestion.description</feature-description>
-            <feature-level>1</feature-level>
-            <feature-url>jsp/admin/plugins/forms/ManageOrderExportableQuestion.jsp</feature-url>
-            <feature-icon-url/>
-        </admin-feature>
-        <admin-feature>
             <feature-id>FORMS_MULTIVIEW</feature-id>
             <feature-title>forms.adminFeature.multiviewForms.name</feature-title>
             <feature-description>forms.adminFeature.multiviewForms.description</feature-description>


### PR DESCRIPTION
This admin feature is not necessary, since a form's questions ranking for export is done within its own configuration:
- **_jsp/admin/plugins/forms/ManageFormExport.jsp?view=manageExport&id_form=_**...

It was also missing the resource properties and a proper _**.jsp**_ file, which just created errors whenever we tried to access it.