### PR TITLE
LUT-32414 : Add management null value when checking response changes for Forms

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeDate.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeDate.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.forms.service.entrytype;
 
 import java.util.List;
 
+import fr.paris.lutece.plugins.forms.util.FormsEntryUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.AbstractEntryTypeDate;
@@ -105,19 +106,6 @@ public class EntryTypeDate extends AbstractEntryTypeDate implements IResponseCom
     @Override
     public boolean isResponseChanged( List<Response> listResponseReference, List<Response> listResponseNew )
     {
-        String strResponseReference = listResponseReference.get( 0 ).getResponseValue( );
-        String strResponseNew = listResponseNew.get( 0 ).getResponseValue( );
-
-        if ( strResponseReference == null && strResponseNew == null )
-        {
-            return false;
-        }
-
-        if ( strResponseReference == null )
-        {
-            return true;
-        }
-
-        return !strResponseReference.equals( strResponseNew );
+        return FormsEntryUtils.isFirstResponseValueChanged( listResponseReference, listResponseNew );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeNumber.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeNumber.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.forms.service.entrytype;
 
 import java.util.List;
 
+import fr.paris.lutece.plugins.forms.util.FormsEntryUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.AbstractEntryTypeNumber;
@@ -106,14 +107,6 @@ public class EntryTypeNumber extends AbstractEntryTypeNumber implements IRespons
     @Override
     public boolean isResponseChanged( List<Response> listResponseReference, List<Response> listResponseNew )
     {
-        String strResponseReference = listResponseReference.get( 0 ).getResponseValue( );
-        String strResponseNew = listResponseNew.get( 0 ).getResponseValue( );
-
-        if ( strResponseReference == null )
-        {
-            return strResponseNew != null;
-        }
-
-        return !strResponseReference.equals( strResponseNew );
+        return FormsEntryUtils.isFirstResponseValueChanged( listResponseReference, listResponseNew );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeNumbering.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeNumbering.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.forms.service.entrytype;
 
 import java.util.List;
 
+import fr.paris.lutece.plugins.forms.util.FormsEntryUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.AbstractEntryTypeNumbering;
@@ -108,13 +109,6 @@ public class EntryTypeNumbering extends AbstractEntryTypeNumbering implements IR
     @Override
     public boolean isResponseChanged( List<Response> listResponseReference, List<Response> listResponseNew )
     {
-        String strResponseReference = listResponseReference.get( 0 ).getResponseValue( );
-        String strResponseNew = listResponseNew.get( 0 ).getResponseValue( );
-
-        if ( strResponseReference == null )
-        {
-            return strResponseNew != null;
-        }
-        return !strResponseReference.equals( strResponseNew );
+        return FormsEntryUtils.isFirstResponseValueChanged( listResponseReference, listResponseNew );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeRadioButton.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeRadioButton.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.forms.service.entrytype;
 
 import java.util.List;
 
+import fr.paris.lutece.plugins.forms.util.FormsEntryUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.AbstractEntryTypeRadioButton;
@@ -104,14 +105,6 @@ public class EntryTypeRadioButton extends AbstractEntryTypeRadioButton implement
     @Override
     public boolean isResponseChanged( List<Response> listResponseReference, List<Response> listResponseNew )
     {
-        String strResponseReference = listResponseReference.get( 0 ).getResponseValue( );
-        String strResponseNew = listResponseNew.get( 0 ).getResponseValue( );
-
-        if ( strResponseReference == null )
-        {
-            return strResponseNew != null;
-        }
-
-        return !strResponseReference.equals( strResponseNew );
+        return FormsEntryUtils.isFirstResponseValueChanged( listResponseReference, listResponseNew );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeSelect.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeSelect.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.forms.service.entrytype;
 
 import java.util.List;
 
+import fr.paris.lutece.plugins.forms.util.FormsEntryUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.AbstractEntryTypeSelect;
@@ -104,13 +105,6 @@ public class EntryTypeSelect extends AbstractEntryTypeSelect implements IRespons
     @Override
     public boolean isResponseChanged( List<Response> listResponseReference, List<Response> listResponseNew )
     {
-        String strResponseReference = listResponseReference.get( 0 ).getResponseValue( );
-        String strResponseNew = listResponseNew.get( 0 ).getResponseValue( );
-
-        if ( strResponseReference == null )
-        {
-            return strResponseNew != null;
-        }
-        return !strResponseReference.equals( strResponseNew );
+        return FormsEntryUtils.isFirstResponseValueChanged( listResponseReference, listResponseNew );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeSelectOrder.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeSelectOrder.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.forms.service.entrytype;
 
 import java.util.List;
 
+import fr.paris.lutece.plugins.forms.util.FormsEntryUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.AbstractEntryTypeSelectOrder;
@@ -104,13 +105,6 @@ public class EntryTypeSelectOrder extends AbstractEntryTypeSelectOrder implement
     @Override
     public boolean isResponseChanged( List<Response> listResponseReference, List<Response> listResponseNew )
     {
-        String strResponseReference = listResponseReference.get( 0 ).getResponseValue( );
-        String strResponseNew = listResponseNew.get( 0 ).getResponseValue( );
-
-        if ( strResponseReference == null )
-        {
-            return strResponseNew != null;
-        }
-        return !strResponseReference.equals( strResponseNew );
+        return FormsEntryUtils.isFirstResponseValueChanged( listResponseReference, listResponseNew );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeTelephoneNumber.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeTelephoneNumber.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.forms.service.entrytype;
 
 import java.util.List;
 
+import fr.paris.lutece.plugins.forms.util.FormsEntryUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.AbstractEntryTypeTelephoneNumber;
@@ -85,18 +86,13 @@ public class EntryTypeTelephoneNumber extends AbstractEntryTypeTelephoneNumber i
         return TEMPLATE_READONLY_BACKOFFICE;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isResponseChanged( List<Response> listResponseReference, List<Response> listResponseNew )
     {
-        String strResponseReference = listResponseReference.get( 0 ).getResponseValue( );
-        String strResponseNew = listResponseNew.get( 0 ).getResponseValue( );
-
-        if ( strResponseReference == null )
-        {
-            return strResponseNew != null;
-        }
-
-        return !strResponseReference.equals( strResponseNew );
+        return FormsEntryUtils.isFirstResponseValueChanged( listResponseReference, listResponseNew );
     }
 
 }

--- a/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeText.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeText.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.forms.service.entrytype;
 
 import java.util.List;
 
+import fr.paris.lutece.plugins.forms.util.FormsEntryUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.AbstractEntryTypeText;
@@ -106,14 +107,6 @@ public class EntryTypeText extends AbstractEntryTypeText implements IResponseCom
     @Override
     public boolean isResponseChanged( List<Response> listResponseReference, List<Response> listResponseNew )
     {
-        String strResponseReference = listResponseReference.get( 0 ).getResponseValue( );
-        String strResponseNew = listResponseNew.get( 0 ).getResponseValue( );
-
-        if ( strResponseReference == null )
-        {
-            return strResponseNew != null;
-        }
-
-        return !strResponseReference.equals( strResponseNew );
+        return FormsEntryUtils.isFirstResponseValueChanged( listResponseReference, listResponseNew );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeTextArea.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/entrytype/EntryTypeTextArea.java
@@ -35,6 +35,7 @@ package fr.paris.lutece.plugins.forms.service.entrytype;
 
 import java.util.List;
 
+import fr.paris.lutece.plugins.forms.util.FormsEntryUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.AbstractEntryTypeTextArea;
@@ -104,14 +105,6 @@ public class EntryTypeTextArea extends AbstractEntryTypeTextArea implements IRes
     @Override
     public boolean isResponseChanged( List<Response> listResponseReference, List<Response> listResponseNew )
     {
-        String strResponseReference = listResponseReference.get( 0 ).getToStringValueResponse( );
-        String strResponseNew = listResponseNew.get( 0 ).getToStringValueResponse( );
-
-        if ( strResponseReference == null )
-        {
-            return strResponseNew != null;
-        }
-
-        return !strResponseReference.equals( strResponseNew );
+        return FormsEntryUtils.isFirstResponseValueChanged( listResponseReference, listResponseNew );
     }
 }

--- a/src/java/fr/paris/lutece/plugins/forms/util/FormsEntryUtils.java
+++ b/src/java/fr/paris/lutece/plugins/forms/util/FormsEntryUtils.java
@@ -35,12 +35,10 @@ package fr.paris.lutece.plugins.forms.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import fr.paris.lutece.plugins.forms.service.FormsPlugin;
-import fr.paris.lutece.plugins.genericattributes.business.Entry;
-import fr.paris.lutece.plugins.genericattributes.business.EntryType;
-import fr.paris.lutece.plugins.genericattributes.business.EntryTypeHome;
-import fr.paris.lutece.plugins.genericattributes.business.Field;
+import fr.paris.lutece.plugins.genericattributes.business.*;
 import fr.paris.lutece.util.ReferenceList;
 
 /**
@@ -173,5 +171,35 @@ public final class FormsEntryUtils
         }
 
         return fieldFound;
+    }
+
+    /**
+     * Check if there is a difference between the current value and the new value in a form.
+     * @param listResponseReference List of current responses.
+     * @param listResponseNew List of new responses.
+     * @return true if the value is changed, false otherwise.
+     */
+    public static boolean isFirstResponseValueChanged( List<Response> listResponseReference, List<Response> listResponseNew )
+    {
+        String strResponseReference = getFirstResponseValue( listResponseReference );
+        String strResponseNew = getFirstResponseValue( listResponseNew );
+
+        return !Objects.equals( strResponseReference, strResponseNew );
+    }
+
+    /**
+     * Get the first response value of the list given in parameter.
+     * Return null if the list is null there is no value in it.
+     * @param listResponses List of responses
+     * @return the first response value of the list given in parameter
+     */
+    public static String getFirstResponseValue( List<Response> listResponses )
+    {
+        if ( listResponses == null || listResponses.isEmpty( ) || listResponses.get( 0 ) == null )
+        {
+            return null;
+        }
+
+        return listResponses.get( 0 ).getResponseValue( );
     }
 }


### PR DESCRIPTION
In Forms, in BO, when we try to update the values of an existing form filled by a FO, if there is a null value in the form, comparing the value with the new one will cause a null pointer exception because a get of the first value in the list will not work, there is not control on the list before this get. So, this will cause the lost of the value in the form. 