### PR TITLE
LUT-32838: Signal the indexer daemon when there is work to do

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/service/search/LuceneFormSearchIndexer.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/search/LuceneFormSearchIndexer.java
@@ -77,6 +77,7 @@ import fr.paris.lutece.plugins.forms.service.entrytype.EntryTypeDate;
 import fr.paris.lutece.plugins.forms.service.entrytype.EntryTypeNumbering;
 import fr.paris.lutece.plugins.forms.service.entrytype.EntryTypeRadioButton;
 import fr.paris.lutece.plugins.forms.service.entrytype.EntryTypeSelect;
+import fr.paris.lutece.plugins.forms.util.IndexerDaemonSignalHelper;
 import fr.paris.lutece.plugins.forms.util.LuceneUtils;
 import fr.paris.lutece.plugins.genericattributes.business.Entry;
 import fr.paris.lutece.plugins.genericattributes.business.Response;
@@ -139,6 +140,8 @@ public class LuceneFormSearchIndexer implements IFormSearchIndexer
         indexerAction.setIdFormResponse( nIdFormResponse );
         indexerAction.setIdTask( nIdTask );
         IndexerActionHome.create( indexerAction, plugin );
+        // signal the indexer daemon that there is work to do
+        IndexerDaemonSignalHelper.signal( );
     }
 
     /**

--- a/src/java/fr/paris/lutece/plugins/forms/util/IndexerDaemonSignalHelper.java
+++ b/src/java/fr/paris/lutece/plugins/forms/util/IndexerDaemonSignalHelper.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2002-2026, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.forms.util;
+
+import javax.servlet.ServletRequestEvent;
+import javax.servlet.ServletRequestListener;
+import javax.servlet.annotation.WebListener;
+import javax.servlet.http.HttpServletRequest;
+
+import fr.paris.lutece.plugins.forms.service.search.FormsSearchIndexerDaemon;
+import fr.paris.lutece.portal.service.daemon.AppDaemonService;
+import fr.paris.lutece.portal.web.LocalVariables;
+
+/**
+ * This request listener ensures that when multiple indexer actions are created
+ * in the scope of a single request, the indexer daemon is signaled only once.
+ */
+@WebListener
+public class IndexerDaemonSignalHelper implements ServletRequestListener
+{
+    private static final String ATTRIBUTE_SIGNAL_INDEXER_DAEMON = "forms.signalIndexerDaemon";
+    private static boolean _initialized;
+
+    public IndexerDaemonSignalHelper( )
+    {
+        // recored that this listener was initialized
+        _initialized = true;
+    }
+
+    /**
+     * Record that the FormsSearchIndexerDaemon should be signaled at the end of this request.
+     * <p>
+     * If no request is found, or if the listener was not initialized, the daemon is signaled immediately.
+     */
+    public static void signal( )
+    {
+        HttpServletRequest request = LocalVariables.getRequest( );
+        if ( request == null || !_initialized )
+        {
+            // Not in a request context, or the listener was not registered.
+            // Signal immediately
+            AppDaemonService.signalDaemon( FormsSearchIndexerDaemon.DAEMON_ID );
+            return;
+        }
+        // inform the request that the daemon should be signaled
+        request.setAttribute( ATTRIBUTE_SIGNAL_INDEXER_DAEMON, Boolean.TRUE );
+    }
+
+    @Override
+    public void requestDestroyed( ServletRequestEvent sre )
+    {
+        if ( sre.getServletRequest( ).getAttribute( ATTRIBUTE_SIGNAL_INDEXER_DAEMON ) != null )
+        {
+            AppDaemonService.signalDaemon( FormsSearchIndexerDaemon.DAEMON_ID );
+        }
+    }
+
+    @Override
+    public void requestInitialized( ServletRequestEvent sre )
+    {
+        // NOOP
+    }
+}

--- a/webapp/WEB-INF/conf/plugins/forms.properties
+++ b/webapp/WEB-INF/conf/plugins/forms.properties
@@ -46,7 +46,7 @@ forms.index.writer.multi.apps=true
 forms.index.writer.auto.initialize=true
 
 daemon.formsIndexerDaemon.onstartup=1
-daemon.formsIndexerDaemon.interval=30
+daemon.formsIndexerDaemon.interval=86400
 
 daemon.formsBackupPurgeDaemon.onstartup=1
 daemon.formsBackupPurgeDaemon.interval=86400


### PR DESCRIPTION
This allows indexation to occur faster, and prevent useless daemon activations in periods of low traffic. The default daemon interval is bumped up to once a day.

When a form response is first saved, two indexation events are emmited :
 * a creation event
 * an update event once the workflow has been initialized

To prevent two indexer activations in rapid succession, coalesce the daemon signaling so that only one is done when the http request is destroyed.