### PR TITLE
LUT-32962 : review fixes on conditional display

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/web/CompositeQuestionDisplay.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/CompositeQuestionDisplay.java
@@ -78,6 +78,7 @@ import fr.paris.lutece.plugins.genericattributes.service.entrytype.EntryTypeServ
 import fr.paris.lutece.plugins.genericattributes.service.entrytype.IEntryTypeService;
 import fr.paris.lutece.portal.service.image.ImageResourceManager;
 import fr.paris.lutece.portal.service.template.AppTemplateService;
+import fr.paris.lutece.portal.service.util.AppLogService;
 import fr.paris.lutece.util.html.HtmlTemplate;
 
 import static fr.paris.lutece.plugins.genericattributes.service.entrytype.IEntryTypeService.SUFFIX_CONFIRM_FIELD;
@@ -264,6 +265,11 @@ public class CompositeQuestionDisplay implements ICompositeDisplay, Serializable
                     {
                         mapControlValidator.put( control, validator );
                         control.setValue( validator.getJavascriptControlValue( control ) );
+                    }
+                    else
+                    {
+                        AppLogService.error( "Forms: validator '" + control.getValidatorName( ) + "' not found for control " + control.getId( )
+                                + " (question " + _question.getId( ) + ") : conditional control ignored on client side" );
                     }
                     if ( CollectionUtils.isNotEmpty( control.getListIdQuestion( ) ) && CollectionUtils.isNotEmpty( listFormQuestionResponse ) )
                     {

--- a/webapp/WEB-INF/templates/admin/plugins/forms/composite/view_question.html
+++ b/webapp/WEB-INF/templates/admin/plugins/forms/composite/view_question.html
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', function() {
 						inputValue = getFieldValue(input${itemControl.id}_${question.iterationNumber});
 						// AND condition : if at least 1 control value isn't present, do not display question
 						var controlDiv = document.querySelector("div[displayControl='${itemControl.listIdQuestion[0]}_${question.iterationNumber}']");
-						if((controlDiv && controlDiv.classList.contains("control_invalid"))	|| !validator_${itemControl.validatorName?replace('.','_')}( inputValue, '${itemControl.value}')){
+						if((controlDiv && controlDiv.classList.contains("control_invalid"))	|| !validator_${itemControl.validatorName?replace('.','_')}( inputValue, '${itemControl.value?js_string}')){
 							nNotValidControlsCount++;
 						} else {
 							nValidControlsCount++;

--- a/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_group_resubmit.html
+++ b/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_group_resubmit.html
@@ -61,13 +61,12 @@
 			group.style.display = allInvalid ? 'none' : '';
 		}
 
-		// trigger the group visibility on any field change
-		document.querySelectorAll('input, select, textarea').forEach(function(field){
-			['change','keyup','paste','mouseup','input'].forEach(function(eventName){
-				field.addEventListener(eventName, function(){
-					setTimeout(syncGroupVisibility, 0);
-				});
-			});
+		// the group visibility only depends on the 'control_invalid' class toggled on the
+		// conditional fields by the question display controls : observe those class changes
+		// directly instead of listening to every field of the page
+		const observer = new MutationObserver(syncGroupVisibility);
+		condFields.forEach(function(field){
+			observer.observe(field, { attributes: true, attributeFilter: ['class'] });
 		});
 		syncGroupVisibility();
 	}

--- a/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_question.html
+++ b/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_question.html
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', function() {
 						inputValue = getFieldValue(input${itemControl.id}_${question.iterationNumber});
 						// AND condition : if at least 1 control value isn't present, do not display question
 						var controlDiv = document.querySelector("div[displayControl='${itemControl.listIdQuestion[0]}_${question.iterationNumber}']");
-						if((controlDiv && controlDiv.classList.contains("control_invalid"))	|| !validator_${itemControl.validatorName?replace('.','_')}( inputValue, '${itemControl.value}')){
+						if((controlDiv && controlDiv.classList.contains("control_invalid"))	|| !validator_${itemControl.validatorName?replace('.','_')}( inputValue, '${itemControl.value?js_string}')){
 							nNotValidControlsCount++;
 						} else {
 							nValidControlsCount++;

--- a/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_question_resubmit.html
+++ b/webapp/WEB-INF/templates/skin/plugins/forms/composite_template/view_question_resubmit.html
@@ -90,7 +90,7 @@
 						const inputValue = getFieldValue(inputItem);
 						const ctrlDiv = document.querySelector("div[displayControl='" + displayItemControl + "']");
 						if( ( ctrlDiv !== null && ctrlDiv.classList.contains("control_invalid") )
-								|| !validator_${itemControl.validatorName?replace('.','_')}( inputValue, '${itemControl.value}') )
+								|| !validator_${itemControl.validatorName?replace('.','_')}( inputValue, '${itemControl.value?js_string}') )
 						{
 							nNotValidControlsCount++;
 						} else {


### PR DESCRIPTION
- replace page-wide field listeners by a per-group MutationObserver on the conditional fields 'class' attribute in view_group_resubmit.html (perf)
- escape control values injected in JS string literals with ?js_string
- log an error when a control references an undeployed validator (control silently ignored on client side, behavior unchanged)

Follow-up of PR #631