### PR TITLE
LUT-32262 : Update return url bouton when user authentified

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -903,17 +903,7 @@ public class FormXPage extends MVCApplication
         {
             UrlItem url = null;
 
-            if ( form.isAuthentificationNeeded( ) )
-            {
-                url= bIsEndMessageDisplayed? new UrlItem( AppPathService.getPortalUrl( ) ):new UrlItem( "" );
-                url.addParameter( MVCUtils.PARAMETER_PAGE, FormResponseXPage.XPAGE_NAME );
-                url.addParameter( MVCUtils.PARAMETER_VIEW, FormResponseXPage.VIEW_FORM_RESPONSE );
-                url.addParameter( FormsConstants.PARAMETER_ID_RESPONSE, nIdFormResponse );
-                url.addParameter( FormsConstants.PARAMETER_ACTION_SUCCESS, "true" );
-
-            }
-            else
-            if ( bIsEndMessageDisplayed )
+            if ( form.isAuthentificationNeeded( ) ||  bIsEndMessageDisplayed)
             {
                 url = new UrlItem( getViewFullUrl( VIEW_STEP ) );
             }

--- a/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/FormXPage.java
@@ -805,7 +805,7 @@ public class FormXPage extends MVCApplication
 
         FormMessage formMessage = FormMessageHome.findByForm( form.getId( ) );
         boolean bIsEndMessageDisplayed = formMessage.getEndMessageDisplay( );
-        String strBackUrl = getBackUrl( form, bIsEndMessageDisplayed, _formResponseManager.getFormResponse( ).getId( ) );
+        String strBackUrl = getBackUrl( form, bIsEndMessageDisplayed );
         initAfterSave( request );
 
         if ( formMessage.getEndMessageDisplay( ) )
@@ -893,7 +893,7 @@ public class FormXPage extends MVCApplication
      *            {@code true} if the end message is displayed, {@code false} otherwise
      * @return the back URL
      */
-    private String getBackUrl( Form form, boolean bIsEndMessageDisplayed, int nIdFormResponse )
+    private String getBackUrl( Form form, boolean bIsEndMessageDisplayed )
     {
         if ( StringUtils.isNotEmpty( form.getReturnUrl( ) ) )
         {


### PR DESCRIPTION
After discussing this ticket in https://dev.lutece.paris.fr/bugtracker/issues/32262 , it was decided that if the form requires authentication, the URL for the back button should return the user to the beginning of the form, exactly as it does when no authentication is required. So, there is no need to make return URL mandatory in the parameter of the forms.