### PR TITLE
LUT-32841 : Add control in form indexer

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/service/search/LuceneFormSearchIndexer.java
+++ b/src/java/fr/paris/lutece/plugins/forms/service/search/LuceneFormSearchIndexer.java
@@ -432,6 +432,13 @@ public class LuceneFormSearchIndexer implements IFormSearchIndexer
         {
             Document doc = null;
             Form form = mapForms.get( formResponse.getFormId( ) );
+            if ( form == null )
+            {
+                AppLogService.error( "Skipping indexation of form response {}: associated form {} not found", formResponse.getId( ),
+                        formResponse.getFormId( ) );
+                continue;
+            }
+
             State formResponseState = null;
             if ( _stateService != null )
             {


### PR DESCRIPTION
Adding this control fix an issue when a response is deleted during an indexation, causing a NullPointerException on form and stopping the indexer formsIndexerDaemon. A control on  formResponse is useless because it's already filtered, but `mapForms.get( formResponse.getFormId( ) ) ` can produce a null form if a response has been deleted during indexation.