### PR TITLE
LUT-33049 : Fix order of responses in CSV/ export

### DIFF
--- a/src/java/fr/paris/lutece/plugins/forms/business/FormDisplayDAO.java
+++ b/src/java/fr/paris/lutece/plugins/forms/business/FormDisplayDAO.java
@@ -61,8 +61,9 @@ public final class FormDisplayDAO implements IFormDisplayDAO
             + "WHERE d.id_step = ? AND d.composite_type = ? order by d.id_parent, d.display_order";
     private static final String SQL_QUERY_SELECT_BY_FROM_STEP_COMPOSITE = SQL_QUERY_SELECTALL + " WHERE id_form = ? AND id_step = ? AND id_composite = ?";
     private static final String SQL_QUERY_SELECT_BY_PARENT_ORDER_BY_QUESTION_EXPORT_DISPLAY_ORDER = "SELECT fd.id_display, fd.id_form, fd.id_step, fd.id_composite, fd.id_parent, fd.display_order, fd.composite_type, fd.display_depth "
-    		+ "FROM forms_display fd LEFT JOIN forms_question fq ON fd.id_composite = fq.id_question "
-    		+ "WHERE fd.id_step = ? AND id_parent = ? ORDER BY fq.export_display_order ASC";
+            + "FROM forms_display fd LEFT JOIN forms_question fq ON fd.id_composite = fq.id_question "
+            + "WHERE fd.id_step = ? AND id_parent = ? "
+            + "ORDER BY fq.export_display_order ASC, fd.display_order ASC";
     
     /**
      * {@inheritDoc }

--- a/src/java/fr/paris/lutece/plugins/forms/export/csv/CSVFileGenerator.java
+++ b/src/java/fr/paris/lutece/plugins/forms/export/csv/CSVFileGenerator.java
@@ -54,6 +54,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -65,10 +66,15 @@ public class CSVFileGenerator extends AbstractFileGenerator
     private static final int FLUSH_SIZE = 1000;
     public static final String UTF8_BOM = "\uFEFF";
 
+
     /**
      * Constructor
-     * 
-     * @param _listFormResponseItems
+     * @param formName
+     * @param formPanel
+     * @param listFormColumn
+     * @param listFormFilter
+     * @param sortConfig
+     * @param fileDescription
      */
     public CSVFileGenerator( String formName, FormPanel formPanel, List<IFormColumn> listFormColumn, List<FormFilter> listFormFilter,
             FormItemSortConfig sortConfig, String fileDescription )
@@ -117,6 +123,7 @@ public class CSVFileGenerator extends AbstractFileGenerator
             if(formResponseList != null && !formResponseList.isEmpty()) {
                 int idForm = formResponseList.get(0).getFormId();
                 List<Question> listQuestions = QuestionHome.getQuestionListByIdFormInQuestionOrder(idForm);
+                listQuestions.sort( Comparator.comparingInt( Question::getExportDisplayOrder ) );
             bos.write(formResponseExport.buildCsvColumnToExport(listQuestions));
             bos.newLine();
                   for (FormResponse formResponse : formResponseList) {

--- a/src/java/fr/paris/lutece/plugins/forms/export/pdf/AbstractPdfFileGenerator.java
+++ b/src/java/fr/paris/lutece/plugins/forms/export/pdf/AbstractPdfFileGenerator.java
@@ -214,7 +214,7 @@ public abstract class AbstractPdfFileGenerator extends AbstractFileGenerator {
     {
         Step step = formResponseStep.getStep( );
 
-        List<FormDisplay> listStepFormDisplay = FormDisplayHome.getFormDisplayListByParent( step.getId( ), 0 );
+        List<FormDisplay> listStepFormDisplay = FormDisplayHome.getFormDisplayListByParentOrderByQuestionExportDisplayOrder( step.getId( ), 0 );
 
         List<PdfCell> listContent = new ArrayList<>( );
         
@@ -258,7 +258,7 @@ public abstract class AbstractPdfFileGenerator extends AbstractFileGenerator {
         Group group = GroupHome.findByPrimaryKey( formDisplay.getCompositeId( ) );
         String groupName = group.getTitle( );
 
-        List<FormDisplay> listGroupDisplay = FormDisplayHome.getFormDisplayListByParent( formResponseStep.getStep( ).getId( ), formDisplay.getId( ) );
+        List<FormDisplay> listGroupDisplay = FormDisplayHome.getFormDisplayListByParentOrderByQuestionExportDisplayOrder( formResponseStep.getStep( ).getId( ), formDisplay.getId( ) );
 
         List<FormQuestionResponse> listFormQuestionResponse = FormQuestionResponseHome.getFormQuestionResponseListByFormResponse(formrResponse.getId());
    if(listFormQuestionResponse != null && !listFormQuestionResponse.isEmpty()) {

--- a/src/java/fr/paris/lutece/plugins/forms/web/admin/AbstractFormQuestionJspBean.java
+++ b/src/java/fr/paris/lutece/plugins/forms/web/admin/AbstractFormQuestionJspBean.java
@@ -271,7 +271,7 @@ public abstract class AbstractFormQuestionJspBean extends AbstractJspBean
      *            The URL to go to after displaying an error message
      * @return The URL to go after performing the action
      */
-    protected String processQuestionUpdate( HttpServletRequest request, String errorRetrunUrl ) throws CodeAlreadyExistsException
+    protected String processQuestionUpdate( HttpServletRequest request, String errorReturnUrl ) throws CodeAlreadyExistsException
     {
         String strIdStep = request.getParameter( FormsConstants.PARAMETER_ID_STEP );
         int nIdStep = NumberUtils.toInt( strIdStep, INTEGER_MINUS_ONE );
@@ -291,7 +291,7 @@ public abstract class AbstractFormQuestionJspBean extends AbstractJspBean
         int nIdEntry = _question.getIdEntry( );
         _entry = getFormDatabaseService( ).findEntryByPrimaryKey( nIdEntry );
 
-        String strError = EntryTypeServiceManager.getEntryTypeService( _entry ).getRequestData( _entry, request, getLocale( ), errorRetrunUrl );
+        String strError = EntryTypeServiceManager.getEntryTypeService( _entry ).getRequestData( _entry, request, getLocale( ), errorReturnUrl );
 
         if ( strError != null )
         {


### PR DESCRIPTION
FormDisplayDAO.java : Export order takes priority but if two questions have the same order number, the visual order take effect
CSVFileGenerator.java : For CSV export, apply the display order
AbstractPdfFileGenerator.java : For PDF using getFormDisplayListByParentOrderByQuestionExportDisplayOrder instead of getFormDisplayListByParent to order the questions

Form : 

<img width="4261" height="1089" alt="image" src="https://github.com/user-attachments/assets/4b49dac1-19f3-4bf7-b8f9-acfde7173cff" />


PDF : 

<img width="1589" height="674" alt="image" src="https://github.com/user-attachments/assets/ddcdc354-160a-4a64-8b45-4d19a1dc7a73" />


CSV : 


<img width="756" height="218" alt="image" src="https://github.com/user-attachments/assets/1ad96300-8f96-4571-ae67-a3dbb503c692" />
